### PR TITLE
Enforce clean build verification

### DIFF
--- a/.github/workflows/latex-lint.yml
+++ b/.github/workflows/latex-lint.yml
@@ -1,0 +1,17 @@
+name: LaTeX Lint
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install chktex
+        run: sudo apt-get update && sudo apt-get install -y chktex
+
+      - name: Run chktex
+        run: chktex -q -n22 -n30 -n1 -n8 -n46 main.tex


### PR DESCRIPTION
Fails CI if warnings or unstable references appear.