### PR TITLE
draft(foundations): add Shadow TRBHG UJ numerical probes

### DIFF
--- a/docs/foundations/SHADOW_TRBHG_UJ_HYBRID_DRAFT.md
+++ b/docs/foundations/SHADOW_TRBHG_UJ_HYBRID_DRAFT.md
@@ -1,0 +1,383 @@
+# Shadow–TRBHG–UJ Hybrid Classifier
+
+## Status
+
+Draft.
+
+Conditional.
+
+This note is a conservative classifier, not a claim of:
+- unknown-sector existence;
+- non-human origin;
+- artificial metric engineering;
+- traversable wormhole construction;
+- faster-than-light transport;
+- new spacetime physics from finite anomaly data.
+
+## Inputs
+
+### Input 1: Shadow of Infinity
+
+A finite observable boundary trace may point toward a limiting or infinite regime without realizing that regime.
+
+\[
+\operatorname{Shadow}(X)
+\neq
+X.
+\]
+
+### Input 2: TRBHG
+
+A time-reversed black-hole geometry is treated only as a causal-orientation template.
+
+\[
+\Theta(\mathcal M,g,\tau,\mathscr I^-,\mathscr I^+)
+=
+(\mathcal M,g,-\tau,\mathscr I^+,\mathscr I^-).
+\]
+
+### Input 3: UJ Unknown-Sector Classifier
+
+Finite nondetection produces bounds.
+
+It does not produce existence.
+
+\[
+\neg \operatorname{Detect}(X)
+\not\Rightarrow
+\exists X.
+\]
+
+## Hybrid Object
+
+Let
+
+\[
+\mathcal O=(D,\Sigma,\varepsilon,A,\tau)
+\]
+
+where:
+
+\[
+D=\text{data},
+\quad
+\Sigma=\text{sensor system},
+\quad
+\varepsilon=\text{uncertainty model},
+\quad
+A=\text{admissibility constraints},
+\quad
+\tau=\text{causal orientation}.
+\]
+
+Define
+
+\[
+\mathsf H(\mathcal O)
+=
+\mathsf C_{\mathrm{UJ}}
+\left(
+\operatorname{Shadow}_{\tau}(\mathcal O),
+\Theta,
+A,
+\varepsilon
+\right).
+\]
+
+## Boundary Rule
+
+A finite record may justify a boundary classification:
+
+\[
+\mathcal O
+\leadsto
+\operatorname{Shadow}_{\tau}(\mathcal O).
+\]
+
+It may not justify an ontological upgrade without an additional witness:
+
+\[
+\operatorname{Shadow}_{\tau}(\mathcal O)
+\not\Rightarrow
+\exists X_{\mathrm{unknown}}.
+\]
+
+## Time-Reversal Shadow Rule
+
+For a future null boundary,
+
+\[
+\operatorname{Shadow}_{\tau}(\mathscr I^+)
+=
+\partial J^-_{\tau}(\mathscr I^+).
+\]
+
+For the reversed orientation,
+
+\[
+\operatorname{Shadow}_{-\tau}(\mathscr I^-)
+=
+\partial J^-_{-\tau}(\mathscr I^-)
+=
+\partial J^+_{\tau}(\mathscr I^-).
+\]
+
+Therefore,
+
+\[
+\Theta
+\bigl(
+\operatorname{Shadow}_{\tau}(\mathscr I^+)
+\bigr)
+=
+\operatorname{Shadow}_{-\tau}(\mathscr I^-).
+\]
+
+## Classifier Guard
+
+For every finite record \(\mathcal O\),
+
+\[
+\mathsf H(\mathcal O)
+\notin
+\{
+\mathrm{CONFIRMED\_UNKNOWN\_SECTOR},
+\mathrm{CONFIRMED\_NON\_HUMAN\_ORIGIN},
+\mathrm{CONFIRMED\_METRIC\_ENGINEERING},
+\mathrm{CONFIRMED\_TRAVERSABLE\_WORMHOLE}
+\}
+\]
+
+unless an independent constructive witness is supplied.
+
+## Allowed Outputs
+
+\[
+\mathsf H(\mathcal O)
+\in
+\{
+\mathrm{MUNDANE},
+\mathrm{SENSOR\_ARTIFACT},
+\mathrm{ENVIRONMENTAL\_ARTIFACT},
+\mathrm{AIR\_DOMAIN\_ADMISSIBLE},
+\mathrm{NON\_AIR\_CANDIDATE},
+\mathrm{UNKNOWN\_SECTOR\_BOUND\_ONLY},
+\mathrm{METRIC\_TOPOLOGY\_CANDIDATE},
+\mathrm{TIME\_REVERSAL\_SHADOW\_TEMPLATE},
+\mathrm{INSUFFICIENT\_DATA}
+\}.
+\]
+
+## Weakest Sufficient Upgrade Rule
+
+An observation may be upgraded from
+
+\[
+\mathrm{UNKNOWN\_SECTOR\_BOUND\_ONLY}
+\]
+
+to
+
+\[
+\mathrm{NON\_AIR\_CANDIDATE}
+\]
+
+only if it supplies:
+
+\[
+\mathrm{calibrated\ multisensor\ coherence}
++
+\mathrm{trajectory\ reconstruction}
++
+\mathrm{artifact\ exclusion}
++
+\mathrm{environmental\ exclusion}.
+\]
+
+It may be upgraded to
+
+\[
+\mathrm{METRIC\_TOPOLOGY\_CANDIDATE}
+\]
+
+only if it additionally supplies:
+
+\[
+\mathrm{causal\ anomaly}
++
+\mathrm{conservation\ closure}
++
+\mathrm{repeatability}
++
+\mathrm{independent\ instrumentation}.
+\]
+
+## Minimal Missing Lemma
+
+For finite observation records,
+
+\[
+\operatorname{Shadow}_{\tau}(\mathcal O)
++
+\Theta
++
+\neg \operatorname{Detect}
+\]
+
+does not imply
+
+\[
+\exists X_{\mathrm{unknown}}.
+\]
+
+## Executable Numerical Probe
+
+The numerical probe is not evidence for an unknown sector.
+
+It tests only the guard logic:
+
+\[
+\mathrm{nondetection}
+\mapsto
+\mathrm{UNKNOWN\_SECTOR\_BOUND\_ONLY}.
+\]
+
+\[
+\min(
+s_{\mathrm{sensor}},
+s_{\mathrm{trajectory}},
+s_{\mathrm{artifact\ exclusion}},
+s_{\mathrm{environmental\ exclusion}}
+)
+\ge 0.80
+\Rightarrow
+\mathrm{NON\_AIR\_CANDIDATE}.
+\]
+
+\[
+\min(
+s_{\mathrm{nonair}},
+s_{\mathrm{causal}},
+s_{\mathrm{conservation}},
+s_{\mathrm{repeatability}},
+s_{\mathrm{independent}}
+)
+\ge 0.85
+\Rightarrow
+\mathrm{METRIC\_TOPOLOGY\_CANDIDATE}.
+\]
+
+It is implemented by:
+
+\[
+\texttt{tools/shadow\_trbhg\_uj\_numeric.py}
+\]
+
+and guarded by:
+
+\[
+\texttt{tests/test\_shadow\_trbhg\_uj\_numeric.py}.
+\]
+
+## Cosmological Boundary Probe
+
+The cosmology numerical probe is not evidence for an unknown sector.
+
+It tests whether a finite boundary-scale value behaves as a shadow value rather than an existence claim.
+
+For rest wavelength \(\lambda_0\) and observed wavelength \(\lambda_{\mathrm{obs}}\),
+
+\[
+z
+=
+\frac{\lambda_{\mathrm{obs}}}{\lambda_0}
+-
+1.
+\]
+
+The low-\(z\) Hubble proxy is
+
+\[
+v
+=
+cz,
+\qquad
+d
+=
+\frac{cz}{H_0}.
+\]
+
+The finite shadow score is
+
+\[
+s_{\mathrm{cosmo}}
+=
+\frac{z}{1+z}.
+\]
+
+For the locked numerical case,
+
+\[
+\lambda_{\mathrm{obs}}=984.42\mathrm{nm},
+\qquad
+\lambda_0=656.28\mathrm{nm},
+\]
+
+so
+
+\[
+z=0.5,
+\qquad
+s_{\mathrm{cosmo}}=\frac13.
+\]
+
+The classifier must preserve:
+
+\[
+s_{\mathrm{cosmo}}=\frac13
+\not\Rightarrow
+\exists X_{\mathrm{unknown}}.
+\]
+
+It is guarded by:
+
+\[
+\texttt{tests/test\_shadow\_trbhg\_uj\_cosmology\_numeric.py}.
+\]
+
+## Repository Placement
+
+Do not index this draft until one of the following is true:
+
+\[
+\text{Either}
+\quad
+\mathsf H
+\text{ is needed by another note,}
+\]
+
+or
+
+\[
+\text{the hybrid produces a strictly new guard not already present in the three source notes.}
+\]
+
+## Decision Criterion
+
+Add permanently only if this file contributes a new invariant:
+
+\[
+\mathrm{finite\ boundary\ trace}
+\neq
+\mathrm{existence\ claim}
+\]
+
+under simultaneous:
+
+\[
+\text{shadow interpretation}
++
+\text{causal reversal template}
++
+\text{unknown-sector nondetection guard}.
+\]

--- a/tests/test_shadow_trbhg_uj_cosmology_numeric.py
+++ b/tests/test_shadow_trbhg_uj_cosmology_numeric.py
@@ -1,0 +1,92 @@
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path("tools/shadow_trbhg_uj_numeric.py")
+spec = importlib.util.spec_from_file_location("shadow_trbhg_uj_numeric", MODULE_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+ObservationScores = mod.ObservationScores
+
+C_KM_S = 299_792.458
+H0_KM_S_MPC = 70.0
+
+def redshift(lambda_observed_nm: float, lambda_rest_nm: float) -> float:
+    return lambda_observed_nm / lambda_rest_nm - 1.0
+
+def low_z_hubble_velocity_km_s(z: float) -> float:
+    return C_KM_S * z
+
+def low_z_hubble_distance_mpc(z: float) -> float:
+    return low_z_hubble_velocity_km_s(z) / H0_KM_S_MPC
+
+def finite_cosmological_shadow_score(z: float) -> float:
+    return z / (1.0 + z)
+
+def test_cosmology_redshift_values_are_numerically_locked():
+    z = redshift(lambda_observed_nm=984.42, lambda_rest_nm=656.28)
+
+    assert round(z, 6) == 0.500000
+    assert round(low_z_hubble_velocity_km_s(z), 3) == 149896.229
+    assert round(low_z_hubble_distance_mpc(z), 3) == 2141.375
+    assert round(finite_cosmological_shadow_score(z), 6) == 0.333333
+
+def test_large_cosmological_shadow_does_not_imply_unknown_sector():
+    z = redshift(lambda_observed_nm=984.42, lambda_rest_nm=656.28)
+    shadow_score = finite_cosmological_shadow_score(z)
+
+    o = ObservationScores(
+        sensor_coherence=shadow_score,
+        trajectory_reconstruction=shadow_score,
+        artifact_exclusion=1.0,
+        environmental_exclusion=1.0,
+    )
+
+    assert shadow_score == 1.0 / 3.0
+    assert mod.classify(o) == "INSUFFICIENT_DATA"
+    assert mod.guard_holds(o)
+
+def test_cosmological_nondetection_remains_bound_only():
+    o = ObservationScores(nondetection_only=True)
+
+    assert mod.classify(o) == "UNKNOWN_SECTOR_BOUND_ONLY"
+    assert mod.guard_holds(o)
+
+def test_cosmology_like_boundary_signal_requires_nonair_witnesses_for_upgrade():
+    o = ObservationScores(
+        sensor_coherence=0.95,
+        trajectory_reconstruction=0.95,
+        artifact_exclusion=0.95,
+        environmental_exclusion=0.95,
+    )
+
+    assert mod.classify(o) == "NON_AIR_CANDIDATE"
+    assert mod.guard_holds(o)
+
+def test_cosmology_like_metric_topology_candidate_requires_all_extra_witnesses():
+    o = ObservationScores(
+        sensor_coherence=0.95,
+        trajectory_reconstruction=0.95,
+        artifact_exclusion=0.95,
+        environmental_exclusion=0.95,
+        causal_anomaly=0.95,
+        conservation_closure=0.95,
+        repeatability=0.95,
+        independent_instrumentation=0.95,
+    )
+
+    assert mod.classify(o) == "METRIC_TOPOLOGY_CANDIDATE"
+    assert mod.guard_holds(o)
+
+def test_time_reversal_shadow_has_orientation_not_existence_content():
+    z = redshift(lambda_observed_nm=984.42, lambda_rest_nm=656.28)
+    forward = mod.theta_shadow_orientation(z, tau=1)
+    reversed_ = mod.theta_shadow_orientation(z, tau=-1)
+
+    assert forward == 0.5
+    assert reversed_ == -0.5
+    assert forward + reversed_ == 0.0
+
+    o = ObservationScores(time_reversal_template=True)
+    assert mod.classify(o) == "TIME_REVERSAL_SHADOW_TEMPLATE"
+    assert mod.guard_holds(o)

--- a/tests/test_shadow_trbhg_uj_numeric.py
+++ b/tests/test_shadow_trbhg_uj_numeric.py
@@ -1,0 +1,118 @@
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path("tools/shadow_trbhg_uj_numeric.py")
+spec = importlib.util.spec_from_file_location("shadow_trbhg_uj_numeric", MODULE_PATH)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+ObservationScores = mod.ObservationScores
+
+def test_nondetection_only_is_bound_only_not_existence():
+    o = ObservationScores(nondetection_only=True)
+    assert mod.classify(o) == "UNKNOWN_SECTOR_BOUND_ONLY"
+    assert mod.guard_holds(o)
+
+def test_non_air_upgrade_requires_four_numerical_witnesses():
+    o = ObservationScores(
+        sensor_coherence=0.90,
+        trajectory_reconstruction=0.86,
+        artifact_exclusion=0.91,
+        environmental_exclusion=0.82,
+    )
+    assert mod.non_air_score(o) == 0.82
+    assert mod.classify(o) == "NON_AIR_CANDIDATE"
+    assert mod.guard_holds(o)
+
+def test_missing_one_non_air_witness_blocks_upgrade():
+    o = ObservationScores(
+        sensor_coherence=0.95,
+        trajectory_reconstruction=0.94,
+        artifact_exclusion=0.93,
+        environmental_exclusion=0.20,
+    )
+    assert mod.non_air_score(o) == 0.20
+    assert mod.classify(o) == "INSUFFICIENT_DATA"
+    assert mod.guard_holds(o)
+
+def test_metric_topology_candidate_requires_extra_four_witnesses():
+    o = ObservationScores(
+        sensor_coherence=0.92,
+        trajectory_reconstruction=0.91,
+        artifact_exclusion=0.93,
+        environmental_exclusion=0.90,
+        causal_anomaly=0.89,
+        conservation_closure=0.88,
+        repeatability=0.87,
+        independent_instrumentation=0.86,
+    )
+    assert mod.metric_topology_score(o) == 0.86
+    assert mod.classify(o) == "METRIC_TOPOLOGY_CANDIDATE"
+    assert mod.guard_holds(o)
+
+def test_metric_topology_downgrades_to_non_air_if_extra_witness_missing():
+    o = ObservationScores(
+        sensor_coherence=0.92,
+        trajectory_reconstruction=0.91,
+        artifact_exclusion=0.93,
+        environmental_exclusion=0.90,
+        causal_anomaly=0.89,
+        conservation_closure=0.20,
+        repeatability=0.87,
+        independent_instrumentation=0.86,
+    )
+    assert mod.metric_topology_score(o) == 0.20
+    assert mod.classify(o) == "NON_AIR_CANDIDATE"
+    assert mod.guard_holds(o)
+
+def test_artifact_and_environmental_artifacts_block_upgrade():
+    sensor = ObservationScores(
+        sensor_coherence=1.0,
+        trajectory_reconstruction=1.0,
+        artifact_exclusion=1.0,
+        environmental_exclusion=1.0,
+        artifact_likelihood=0.90,
+    )
+    environmental = ObservationScores(
+        sensor_coherence=1.0,
+        trajectory_reconstruction=1.0,
+        artifact_exclusion=1.0,
+        environmental_exclusion=1.0,
+        environmental_likelihood=0.90,
+    )
+    assert mod.classify(sensor) == "SENSOR_ARTIFACT"
+    assert mod.classify(environmental) == "ENVIRONMENTAL_ARTIFACT"
+
+def test_air_domain_admissibility_blocks_non_air_upgrade():
+    o = ObservationScores(
+        sensor_coherence=1.0,
+        trajectory_reconstruction=1.0,
+        artifact_exclusion=1.0,
+        environmental_exclusion=1.0,
+        air_domain_admissible=True,
+    )
+    assert mod.classify(o) == "AIR_DOMAIN_ADMISSIBLE"
+    assert mod.guard_holds(o)
+
+def test_time_reversal_shadow_orientation_is_antisymmetric():
+    x = 3.75
+    assert mod.theta_shadow_orientation(x, tau=1) == 3.75
+    assert mod.theta_shadow_orientation(x, tau=-1) == -3.75
+    assert mod.theta_shadow_orientation(x, tau=1) + mod.theta_shadow_orientation(x, tau=-1) == 0.0
+
+def test_forbidden_labels_are_never_returned_on_grid():
+    values = [0.0, 0.25, 0.5, 0.8, 0.85, 1.0]
+    for a in values:
+        for b in values:
+            o = ObservationScores(
+                sensor_coherence=a,
+                trajectory_reconstruction=b,
+                artifact_exclusion=1.0,
+                environmental_exclusion=1.0,
+                causal_anomaly=a,
+                conservation_closure=b,
+                repeatability=1.0,
+                independent_instrumentation=1.0,
+            )
+            assert mod.classify(o) not in mod.FORBIDDEN
+            assert mod.classify(o) in mod.ALLOWED

--- a/tools/shadow_trbhg_uj_numeric.py
+++ b/tools/shadow_trbhg_uj_numeric.py
@@ -1,0 +1,115 @@
+from dataclasses import dataclass
+
+FORBIDDEN = {
+    "CONFIRMED_UNKNOWN_SECTOR",
+    "CONFIRMED_NON_HUMAN_ORIGIN",
+    "CONFIRMED_METRIC_ENGINEERING",
+    "CONFIRMED_TRAVERSABLE_WORMHOLE",
+}
+
+ALLOWED = {
+    "MUNDANE",
+    "SENSOR_ARTIFACT",
+    "ENVIRONMENTAL_ARTIFACT",
+    "AIR_DOMAIN_ADMISSIBLE",
+    "NON_AIR_CANDIDATE",
+    "UNKNOWN_SECTOR_BOUND_ONLY",
+    "METRIC_TOPOLOGY_CANDIDATE",
+    "TIME_REVERSAL_SHADOW_TEMPLATE",
+    "INSUFFICIENT_DATA",
+}
+
+@dataclass(frozen=True)
+class ObservationScores:
+    sensor_coherence: float = 0.0
+    trajectory_reconstruction: float = 0.0
+    artifact_exclusion: float = 0.0
+    environmental_exclusion: float = 0.0
+    causal_anomaly: float = 0.0
+    conservation_closure: float = 0.0
+    repeatability: float = 0.0
+    independent_instrumentation: float = 0.0
+    nondetection_only: bool = False
+    air_domain_admissible: bool = False
+    artifact_likelihood: float = 0.0
+    environmental_likelihood: float = 0.0
+    time_reversal_template: bool = False
+
+def clamp01(x: float) -> float:
+    return max(0.0, min(1.0, float(x)))
+
+def non_air_score(o: ObservationScores) -> float:
+    return min(
+        clamp01(o.sensor_coherence),
+        clamp01(o.trajectory_reconstruction),
+        clamp01(o.artifact_exclusion),
+        clamp01(o.environmental_exclusion),
+    )
+
+def metric_topology_score(o: ObservationScores) -> float:
+    return min(
+        non_air_score(o),
+        clamp01(o.causal_anomaly),
+        clamp01(o.conservation_closure),
+        clamp01(o.repeatability),
+        clamp01(o.independent_instrumentation),
+    )
+
+def classify(o: ObservationScores) -> str:
+    if o.nondetection_only:
+        return "UNKNOWN_SECTOR_BOUND_ONLY"
+
+    if clamp01(o.artifact_likelihood) >= 0.70:
+        return "SENSOR_ARTIFACT"
+
+    if clamp01(o.environmental_likelihood) >= 0.70:
+        return "ENVIRONMENTAL_ARTIFACT"
+
+    if o.air_domain_admissible:
+        return "AIR_DOMAIN_ADMISSIBLE"
+
+    if metric_topology_score(o) >= 0.85:
+        return "METRIC_TOPOLOGY_CANDIDATE"
+
+    if non_air_score(o) >= 0.80:
+        return "NON_AIR_CANDIDATE"
+
+    if o.time_reversal_template:
+        return "TIME_REVERSAL_SHADOW_TEMPLATE"
+
+    return "INSUFFICIENT_DATA"
+
+def guard_holds(o: ObservationScores) -> bool:
+    return classify(o) in ALLOWED and classify(o) not in FORBIDDEN
+
+def theta_shadow_orientation(value: float, tau: int = 1) -> float:
+    if tau not in (-1, 1):
+        raise ValueError("tau must be +1 or -1")
+    return tau * float(value)
+
+if __name__ == "__main__":
+    cases = {
+        "bound_only": ObservationScores(nondetection_only=True),
+        "non_air": ObservationScores(
+            sensor_coherence=0.91,
+            trajectory_reconstruction=0.88,
+            artifact_exclusion=0.93,
+            environmental_exclusion=0.86,
+        ),
+        "metric_topology": ObservationScores(
+            sensor_coherence=0.93,
+            trajectory_reconstruction=0.91,
+            artifact_exclusion=0.95,
+            environmental_exclusion=0.90,
+            causal_anomaly=0.88,
+            conservation_closure=0.87,
+            repeatability=0.89,
+            independent_instrumentation=0.92,
+        ),
+    }
+
+    for name, obs in cases.items():
+        label = classify(obs)
+        assert label in ALLOWED
+        assert label not in FORBIDDEN
+        print(f"{name}: {label}")


### PR DESCRIPTION
Draft only.

Adds a conservative Shadow–TRBHG–UJ hybrid classifier plus numerical guard probes.

Validation:
- python3 -m pytest -q
- python3 tools/shadow_trbhg_uj_numeric.py

No unknown-sector, non-human-origin, metric-engineering, or traversable-wormhole claim is made.