### PR TITLE
docs(foundations): add Frontier Calculus doctrine

### DIFF
--- a/docs/foundations/FRONTIER_CALCULUS.md
+++ b/docs/foundations/FRONTIER_CALCULUS.md
@@ -1,0 +1,45 @@
+# Frontier Calculus
+
+Status: Doctrine / Repository-Governance Layer
+
+## Core Principle
+
+A research repository can be complete without proving the target theorem, provided it certifies the smallest remaining obstruction.
+
+Completion is not identical to solution.
+
+Completion means:
+
+1. The target is explicit.
+2. The admissible methods are registered.
+3. All weaker obstructions are handled.
+4. The smallest surviving obstruction is named.
+5. Future progress requires either:
+   - a stronger negative closure certificate, or
+   - a new separating invariant.
+
+## Normal Form
+
+A frontier-complete repository contains:
+
+- TARGET.md
+- METHOD_REGISTRY.json
+- FRONTIER.md
+- NEGATIVE_CLOSURE_CERTIFICATE.json
+
+## Legal Transitions
+
+A project may advance only by:
+
+1. Solving the target theorem.
+2. Shrinking the frontier.
+3. Strengthening the negative closure certificate.
+4. Introducing a new invariant that separates the current obstruction.
+
+## Forbidden Transition
+
+A repository must not mark an open theorem as solved merely because the surrounding artifact surface is complete.
+
+## Canonical Slogan
+
+Completion means the remaining gap has been made exact.

--- a/docs/status/FRONTIER_CALCULUS_ADOPTION.md
+++ b/docs/status/FRONTIER_CALCULUS_ADOPTION.md
@@ -1,0 +1,25 @@
+# Frontier Calculus Adoption Status
+
+Status: Adopted as a documentation and audit pattern.
+
+This file does not claim that any open theorem is solved.
+
+It records Frontier Calculus as a repository-normalization layer for distinguishing:
+
+- solved theorem,
+- closed executable surface,
+- certified frontier,
+- open mathematical obstruction.
+
+Canonical target use:
+
+- urf-core
+- urf-textbook
+- chronos-urf-rr
+- clay-problem-lab
+- ym-os-quantization
+- pachner-invariant
+
+Adoption rule:
+
+A repository may use Frontier Calculus only when it explicitly names its target, method registry, frontier object, and negative closure certificate.

--- a/tests/test_frontier_calculus_doctrine.py
+++ b/tests/test_frontier_calculus_doctrine.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+def test_frontier_calculus_foundation_doc_exists():
+    p = ROOT / "docs/foundations/FRONTIER_CALCULUS.md"
+    assert p.exists()
+    text = p.read_text()
+    assert "Completion is not identical to solution." in text
+    assert "Completion means the remaining gap has been made exact." in text
+    assert "Forbidden Transition" in text
+
+def test_frontier_calculus_adoption_doc_is_non_overclaiming():
+    p = ROOT / "docs/status/FRONTIER_CALCULUS_ADOPTION.md"
+    assert p.exists()
+    text = p.read_text()
+    assert "This file does not claim that any open theorem is solved." in text
+    assert "open mathematical obstruction" in text
+
+def test_frontier_calculus_verifier_runs():
+    import subprocess, sys
+    result = subprocess.run(
+        [sys.executable, "tools/verify_frontier_calculus.py"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout

--- a/tools/verify_frontier_calculus.py
+++ b/tools/verify_frontier_calculus.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED = {
+    "docs/foundations/FRONTIER_CALCULUS.md": [
+        "Status: Doctrine / Repository-Governance Layer",
+        "Completion is not identical to solution.",
+        "Completion means the remaining gap has been made exact.",
+        "NEGATIVE_CLOSURE_CERTIFICATE.json",
+        "Forbidden Transition",
+    ],
+    "docs/status/FRONTIER_CALCULUS_ADOPTION.md": [
+        "Status: Adopted as a documentation and audit pattern.",
+        "This file does not claim that any open theorem is solved.",
+        "closed executable surface",
+        "certified frontier",
+        "open mathematical obstruction",
+    ],
+}
+
+def main() -> None:
+    for rel, needles in REQUIRED.items():
+        path = ROOT / rel
+        if not path.exists():
+            raise SystemExit(f"missing required file: {rel}")
+        text = path.read_text()
+        for needle in needles:
+            if needle not in text:
+                raise SystemExit(f"missing required text in {rel}: {needle}")
+    print("frontier calculus doctrine verified")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds Frontier Calculus as a repository-governance doctrine.

This distinguishes solved theorem, closed executable surface, certified frontier, and open mathematical obstruction.

Validation:
- python3 tools/verify_frontier_calculus.py
- python3 -m pytest -q

No open theorem is marked solved.