### PR TITLE
docs(status): add URF survival protocol

### DIFF
--- a/docs/status/SURVIVAL_PROTOCOL.md
+++ b/docs/status/SURVIVAL_PROTOCOL.md
@@ -1,0 +1,57 @@
+# URF Survival Protocol
+
+Status: Repository-governance protocol
+
+## Core Claim
+
+The Unified Rigidity Framework is presented as a verification and status-control framework for hard research artifacts.
+
+It does not require every target theorem to be solved.
+
+It requires every repository to distinguish:
+
+- solved theorem,
+- closed executable surface,
+- certified frontier,
+- conditional result,
+- open obstruction.
+
+## Survival Rule
+
+A repository survives skeptical review when a reader can determine:
+
+1. the target,
+2. the verified surface,
+3. the remaining obstruction,
+4. the command that checks the status,
+5. whether any theorem is still open.
+
+## Forbidden Claims
+
+A repository must not imply that an open theorem is solved because:
+
+- tests pass,
+- documentation is complete,
+- a certificate exists,
+- a frontier has been isolated,
+- a reduction is complete.
+
+## Canonical Public Claim
+
+The durable contribution is the conversion of unfinished research into auditable frontier-normalized artifacts.
+
+## Repository Classes
+
+Class A: Canonical / Safe  
+Class B: Frontier / Experimental  
+Class C: Archive / Idea Layer
+
+Only Class A repositories should carry the public-facing program.
+Class B repositories may be cited only as frontier artifacts.
+Class C repositories should remain quiet unless normalized.
+
+## Continuation Rule
+
+Continue only by consolidation, verification, status normalization, or external review preparation.
+
+Do not expand the framework merely by naming new modules.

--- a/tests/test_survival_protocol.py
+++ b/tests/test_survival_protocol.py
@@ -1,0 +1,21 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+def test_survival_protocol_doc_exists():
+    p = ROOT / "docs/status/SURVIVAL_PROTOCOL.md"
+    assert p.exists()
+    text = p.read_text()
+    assert "The durable contribution is the conversion of unfinished research into auditable frontier-normalized artifacts." in text
+    assert "Do not expand the framework merely by naming new modules." in text
+
+def test_survival_protocol_verifier_runs():
+    result = subprocess.run(
+        [sys.executable, "tools/verify_survival_protocol.py"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout

--- a/tools/verify_survival_protocol.py
+++ b/tools/verify_survival_protocol.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs/status/SURVIVAL_PROTOCOL.md"
+
+REQUIRED = [
+    "Status: Repository-governance protocol",
+    "solved theorem",
+    "closed executable surface",
+    "certified frontier",
+    "conditional result",
+    "open obstruction",
+    "A repository must not imply that an open theorem is solved",
+    "conversion of unfinished research into auditable frontier-normalized artifacts",
+    "Continue only by consolidation",
+]
+
+def main() -> None:
+    if not DOC.exists():
+        raise SystemExit("missing docs/status/SURVIVAL_PROTOCOL.md")
+    text = DOC.read_text()
+    for needle in REQUIRED:
+        if needle not in text:
+            raise SystemExit(f"missing required text: {needle}")
+    print("survival protocol verified")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a survival protocol for presenting URF as a verification and status-control framework.

This locks the distinction between solved theorem, closed executable surface, certified frontier, conditional result, and open obstruction.

Validation:
- python3 tools/verify_survival_protocol.py
- python3 -m pytest -q

No open theorem is marked solved.