### PR TITLE
docs(ai): add agent entrypoint and claim boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md — AI Agent Instructions
+
+Status: AI-NAVIGATION ENTRYPOINT.
+
+Repository: `urf-textbook`
+
+Purpose: make this repository easier for AI agents, reviewers, and verification tools to use without overclaiming.
+
+## Canonical AI rule
+
+Read repository status files and verifier outputs before summarizing claims.
+
+Do not infer theorem completion from README language alone.
+
+## Repository claim boundary
+
+This repository has an executable/status surface.
+
+Claims must be restricted to the certified scope stated in repository-local status files, tests, certificates, and verifier outputs.
+
+This repository does not claim full theorem-layer completion unless a repository-local status file explicitly states that exact claim and the verifier suite supports it.
+
+## AI behavior rules
+
+An AI agent may say:
+
+- "This repository has an executable/status surface."
+- "Claims must be restricted to the certified scope stated in AGENTS.md and docs/status."
+- "Verifier commands should be run before reporting completion."
+
+An AI agent must not say:
+
+- "The full theorem layer is complete."
+- "The general mathematical problem is solved."
+- "All future obligations are closed."
+
+unless a repository-local status file explicitly states that exact claim and the verifier suite supports it.
+
+## Safe reading order
+
+1. `AGENTS.md`
+2. `README.md`
+3. `docs/status/`
+4. `tools/`
+5. `tests/`
+6. certificate or artifact data, if present
+
+## Weakest remaining obligation
+
+External/general theorem-layer obligations outside the current certified executable/status surface.

--- a/docs/status/AI_ENTRYPOINT_2026_04_25.md
+++ b/docs/status/AI_ENTRYPOINT_2026_04_25.md
@@ -1,0 +1,34 @@
+# AI Entrypoint — urf-textbook
+
+Status: CANONICAL AI ENTRYPOINT.
+
+This file exists so that AI agents can use the repository safely without reading only the README.
+
+## Repository
+
+`urf-textbook`
+
+## Current certified scope
+
+Repository-local executable/status surface only.
+
+## Safe one-line summary
+
+This repository should be interpreted through its executable/status surface and explicit claim-boundary files. It should not be summarized as full theorem-layer completion unless that exact claim is explicitly certified.
+
+## Machine-readable status
+
+```json
+{
+  "repository": "urf-textbook",
+  "ai_entrypoint": true,
+  "full_theorem_layer_complete": false,
+  "general_problem_complete": false,
+  "claim_boundary_required": true,
+  "canonical_files": [
+    "AGENTS.md",
+    "README.md",
+    "docs/status/"
+  ]
+}
+```

--- a/tests/test_ai_entrypoint_2026_04_25.py
+++ b/tests/test_ai_entrypoint_2026_04_25.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+AGENTS = Path("AGENTS.md")
+ENTRY = Path("docs/status/AI_ENTRYPOINT_2026_04_25.md")
+
+
+def test_agents_file_exists_and_locks_claim_boundary():
+    text = AGENTS.read_text(encoding="utf-8")
+
+    assert "AI-NAVIGATION ENTRYPOINT" in text
+    assert "Do not infer theorem completion from README language alone." in text
+    assert "must not say" in text
+    assert "The full theorem layer is complete." in text
+    assert "External/general theorem-layer obligations" in text
+
+
+def test_ai_entrypoint_exists_and_is_machine_readable():
+    text = ENTRY.read_text(encoding="utf-8")
+
+    assert "CANONICAL AI ENTRYPOINT" in text
+    assert '"ai_entrypoint": true' in text
+    assert '"full_theorem_layer_complete": false' in text
+    assert '"claim_boundary_required": true' in text


### PR DESCRIPTION
Adds AGENTS.md, an AI entrypoint status file, and tests locking claim-boundary language. This avoids README-only overclaiming and gives agents canonical verification instructions.