### PR TITLE
docs(status): add external status lock

### DIFF
--- a/.github/workflows/external-status-lock.yml
+++ b/.github/workflows/external-status-lock.yml
@@ -1,0 +1,13 @@
+name: external-status-lock
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  external-status-lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify external status lock
+        run: python3 scripts/verify_external_status_lock.py

--- a/README.md
+++ b/README.md
@@ -87,3 +87,6 @@ Start here:
 - [Call for Independent Forks and Verification](CALL_FOR_INDEPENDENT_FORKS.md)
 - [Canonical discussion thread](https://github.com/inaciovasquez2020/urf-textbook/discussions/52)
 
+## External status
+
+This repository is governed by [`docs/status/EXTERNAL_STATUS_LOCK.md`](docs/status/EXTERNAL_STATUS_LOCK.md). Build success, CI success, dashboards, ledgers, axioms, admits, `sorry`, or placeholder witnesses do not constitute theorem-level closure.

--- a/docs/status/EXTERNAL_STATUS_LOCK.md
+++ b/docs/status/EXTERNAL_STATUS_LOCK.md
@@ -1,0 +1,32 @@
+# External Status Lock
+
+Date: 2026-04-27
+
+Status: **ACTIVE_EXPOSITION**
+
+Scope:
+
+Expository and governance layer. It documents the program and does not independently prove theorem-level claims.
+
+Boundary:
+
+- Axioms, admits, `sorry`, placeholder witnesses, string witnesses, dashboards, ledgers, and narrative wrappers are not theorem proofs.
+- CI/build success means the checked surface compiles or verifies; it does not upgrade conditional mathematics into theorem-level closure.
+- Any result depending on an axiom, admit, `sorry`, synthetic placeholder, or explicitly named missing lemma is conditional.
+- This repository must not be described as proving a Clay problem, RH, P vs NP, BSD, Hodge, Navier--Stokes, Yang--Mills, Collatz, Goldbach, twin primes, or ABC unless the proof is present without assuming the target theorem.
+
+Allowed public description:
+
+- executable artifact;
+- conditional reduction;
+- certified frontier;
+- audit/status infrastructure;
+- exposition or dashboard;
+- finite verification surface.
+
+Forbidden public description:
+
+- unconditional final proof;
+- solved Millennium Prize problem;
+- theorem-level closure from assumed axioms;
+- machine-checked proof when the central theorem depends on `axiom`, `admit`, `sorry`, or a tautological witness.

--- a/scripts/verify_external_status_lock.py
+++ b/scripts/verify_external_status_lock.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import re
+import sys
+
+status = Path("docs/status/EXTERNAL_STATUS_LOCK.md")
+if not status.exists():
+    raise SystemExit("missing docs/status/EXTERNAL_STATUS_LOCK.md")
+
+text = status.read_text(encoding="utf-8")
+
+required = [
+    "Axioms, admits, `sorry`, placeholder witnesses, string witnesses, dashboards, ledgers, and narrative wrappers are not theorem proofs.",
+    "CI/build success means the checked surface compiles or verifies; it does not upgrade conditional mathematics into theorem-level closure.",
+    "Any result depending on an axiom, admit, `sorry`, synthetic placeholder, or explicitly named missing lemma is conditional.",
+    "Forbidden public description:",
+]
+
+for s in required:
+    if s not in text:
+        raise SystemExit(f"missing required status boundary: {s}")
+
+readme_paths = [Path("README.md"), Path("README"), Path("readme.md")]
+readme_text = "\n".join(p.read_text(encoding="utf-8", errors="ignore") for p in readme_paths if p.exists())
+
+dangerous_patterns = [
+    r"\bwe prove the Riemann Hypothesis\b",
+    r"\bwe prove RH\b",
+    r"\bwe prove P\s*(?:!=|≠)\s*NP\b",
+    r"\bwe prove the Hodge Conjecture\b",
+    r"\bwe prove (?:BSD|Birch[-– ]Swinnerton[-– ]Dyer)\b",
+    r"\bwe prove Navier[-– ]Stokes\b",
+    r"\bwe prove Yang[-– ]Mills\b",
+    r"\bwe prove the mass gap\b",
+    r"\bwe solve the Clay\b",
+    r"\bMillennium Prize solution\b",
+    r"\bunconditional solution\b",
+    r"\btheorem-complete solution\b",
+]
+
+for pat in dangerous_patterns:
+    if re.search(pat, readme_text, flags=re.IGNORECASE):
+        raise SystemExit(f"dangerous README claim matched: {pat}")
+
+print("external status lock: PASS")

--- a/tests/test_external_status_lock.py
+++ b/tests/test_external_status_lock.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import subprocess
+import sys
+
+def test_external_status_lock_present():
+    p = Path("docs/status/EXTERNAL_STATUS_LOCK.md")
+    assert p.exists()
+    text = p.read_text(encoding="utf-8")
+    assert "not theorem proofs" in text
+    assert "does not upgrade conditional mathematics" in text
+    assert "Forbidden public description:" in text
+
+def test_external_status_lock_verifier_passes():
+    script = Path("scripts/verify_external_status_lock.py")
+    assert script.exists()
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    assert result.returncode == 0, result.stdout


### PR DESCRIPTION
Adds an external status lock for this repository.

Boundary:
- build/CI success is not theorem-level closure;
- axioms, admits, sorry, placeholder witnesses, ledgers, and dashboards are not theorem proofs;
- conditional/frontier/scaffold status remains explicit.

Verified:
- python3 scripts/verify_external_status_lock.py
- python3 -m py_compile scripts/verify_external_status_lock.py
