### PR TITLE
docs(status): add textbook source-of-truth boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,16 @@ Start here:
 - [Call for Independent Forks and Verification](CALL_FOR_INDEPENDENT_FORKS.md)
 - [Canonical discussion thread](https://github.com/inaciovasquez2020/urf-textbook/discussions/52)
 
+## Documentation Source-of-Truth Status
+
+Status: Documentation / Textbook Surface
+
+This repository is an exposition surface. It does not independently prove mathematical claims.
+
+Theorem-status rule:
+- Every theorem-level claim must inherit from a buildable formal source repository.
+- The inherited source must identify repository, commit or release, file path, theorem/artifact name, and status label.
+- Build success, LaTeX success, dashboards, badges, ledgers, or textbook exposition do not constitute theorem-level proof.
+
+Source-of-truth document:
+- `docs/status/SOURCE_OF_TRUTH_2026_04_27.md`

--- a/docs/status/SOURCE_OF_TRUTH_2026_04_27.md
+++ b/docs/status/SOURCE_OF_TRUTH_2026_04_27.md
@@ -1,0 +1,31 @@
+# Source of Truth — 2026-04-27
+
+Status: Documentation / Textbook Surface
+
+This repository is a documentation, textbook, exposition, or synthesis surface. It does not independently prove mathematical claims. Any theorem status must inherit from a buildable formal repository and must use that repository's status label.
+
+## Inheritance rule
+
+Every theorem-level claim must point to:
+
+- source repository
+- commit or release identifier
+- file path
+- theorem or artifact name
+- inherited status label
+
+## Allowed inherited labels
+
+- Verified
+- Conditional
+- Scaffold
+- Quarantined Frontier
+- Deprecated / Narrative
+- Toy Verified Skeleton
+- Toy Cardinality Model / Not a Real Bridge
+- Clean Formal Scaffold / Needs Theorem Audit
+- Placeholder / Scaffold
+
+## Boundary rule
+
+This repository must not claim independent theorem verification. Build success, LaTeX success, CI success, dashboards, ledgers, badges, or textbook exposition do not constitute theorem-level proof.

--- a/scripts/check_textbook_source_of_truth_status.py
+++ b/scripts/check_textbook_source_of_truth_status.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+STATUS_DOC = ROOT / "docs/status/SOURCE_OF_TRUTH_2026_04_27.md"
+README = ROOT / "README.md"
+
+def main() -> int:
+    if not STATUS_DOC.exists():
+        print(f"missing status document: {STATUS_DOC.relative_to(ROOT)}")
+        return 1
+    if not README.exists():
+        print("missing README.md")
+        return 1
+
+    status_text = STATUS_DOC.read_text(encoding="utf-8", errors="ignore")
+    readme_text = README.read_text(encoding="utf-8", errors="ignore")
+
+    required_status = [
+        "Status: Documentation / Textbook Surface",
+        "does not independently prove mathematical claims",
+        "Any theorem status must inherit from a buildable formal repository",
+        "This repository must not claim independent theorem verification.",
+    ]
+
+    required_readme = [
+        "## Documentation Source-of-Truth Status",
+        "Status: Documentation / Textbook Surface",
+        "It does not independently prove mathematical claims.",
+        "Every theorem-level claim must inherit from a buildable formal source repository.",
+        "`docs/status/SOURCE_OF_TRUTH_2026_04_27.md`",
+    ]
+
+    missing = [s for s in required_status if s not in status_text]
+    missing += [s for s in required_readme if s not in readme_text]
+
+    if missing:
+        print("textbook source-of-truth status check failed")
+        for s in missing:
+            print(f"missing: {s}")
+        return 1
+
+    print({
+        "status": "PASS",
+        "classification": "Documentation / Textbook Surface",
+        "status_doc": str(STATUS_DOC.relative_to(ROOT)),
+        "readme_status_block": "PASS",
+    })
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_textbook_source_of_truth_status.py
+++ b/tests/test_textbook_source_of_truth_status.py
@@ -1,0 +1,8 @@
+import subprocess
+import sys
+
+def test_textbook_source_of_truth_status_guard_passes():
+    subprocess.run(
+        [sys.executable, "scripts/check_textbook_source_of_truth_status.py"],
+        check=True,
+    )


### PR DESCRIPTION
Classifies urf-textbook as a Documentation / Textbook Surface.

Verified:
- scripts/check_textbook_source_of_truth_status.py passes
- pytest passes

Boundary:
- This repository does not independently prove mathematical claims.
- Every theorem-level claim must inherit from a buildable formal source repository.
- Build success, LaTeX success, dashboards, badges, ledgers, or textbook exposition do not constitute theorem-level proof.