### PR TITLE
docs(vtd): include gravity-reference uncertainty in certificate

### DIFF
--- a/docs/frontier/VTD_TRAJECTORY_ANOMALY_CERTIFICATE.md
+++ b/docs/frontier/VTD_TRAJECTORY_ANOMALY_CERTIFICATE.md
@@ -8,7 +8,7 @@ Let
 D=\{(t_i,z_i)\}_{i=1}^{N},\qquad t_1<\cdots<t_N,
 \]
 
-be a vacuum vertical trajectory in SI units. Let \(m>0\), \(g>0\), \(\varepsilon_{\mathrm{meas}}\ge 0\), and \(\varepsilon_F\ge 0\).
+be a vacuum vertical trajectory in SI units. Let \(m>0\), \(g_{\mathrm{cert}}>0\), \(\varepsilon_g\ge 0\), \(\varepsilon_{\mathrm{meas}}\ge 0\), and \(\varepsilon_F\ge 0\).
 
 A VTD certificate consists of
 
@@ -16,11 +16,15 @@ A VTD certificate consists of
 \mathrm{VTD}
 =
 \left(
-D,m,g,\widehat a(t^\star),\varepsilon_{\mathrm{meas}},\varepsilon_F
+D,m,g_{\mathrm{cert}},\varepsilon_g,\widehat a(t^\star),\varepsilon_{\mathrm{meas}},\varepsilon_F
 \right),
 \]
 
 where
+
+\[
+|g_{\mathrm{cert}}-g_{\mathrm{true}}|\le \varepsilon_g,
+\]
 
 \[
 |\widehat a(t^\star)-z''(t^\star)|\le \varepsilon_{\mathrm{meas}}
@@ -39,7 +43,7 @@ and
 H_0:\qquad
 z''(t^\star)
 =
--g+\frac{F_{\mathrm{non\text{-}gravity}}(t^\star)}{m}.
+-g_{\mathrm{true}}+\frac{F_{\mathrm{non\text{-}gravity}}(t^\star)}{m}.
 \]
 
 ## Anomaly model
@@ -52,7 +56,7 @@ z''(t^\star)
 +
 \frac{F_{\mathrm{non\text{-}gravity}}(t^\star)}{m},
 \qquad
-g_{\mathrm{eff}}\ne g .
+g_{\mathrm{eff}}\ne g_{\mathrm{true}} .
 \]
 
 ## Conditional theorem
@@ -60,21 +64,23 @@ g_{\mathrm{eff}}\ne g .
 If the two certificate bounds above are valid and
 
 \[
-|\widehat a(t^\star)+g|
+|\widehat a(t^\star)+g_{\mathrm{cert}}|
 >
-\varepsilon_{\mathrm{meas}}+\varepsilon_F,
+\varepsilon_{\mathrm{meas}}+\varepsilon_F+\varepsilon_g,
 \]
 
 then \(H_0\) is falsified at \(t^\star\), and
 
 \[
-|g_{\mathrm{eff}}-g|
+|g_{\mathrm{eff}}-g_{\mathrm{true}}|
 \ge
-|\widehat a(t^\star)+g|
+|\widehat a(t^\star)+g_{\mathrm{cert}}|
 -
 \varepsilon_{\mathrm{meas}}
 -
 \varepsilon_F
+-
+\varepsilon_g
 >
 0.
 \]
@@ -84,7 +90,7 @@ then \(H_0\) is falsified at \(t^\star\), and
 Under \(H_0\),
 
 \[
-z''(t^\star)+g
+z''(t^\star)+g_{\mathrm{true}}
 =
 \frac{F_{\mathrm{non\text{-}gravity}}(t^\star)}{m}.
 \]
@@ -92,9 +98,9 @@ z''(t^\star)+g
 Therefore
 
 \[
-|z''(t^\star)+g|
+|z''(t^\star)+g_{\mathrm{cert}}|
 \le
-\varepsilon_F.
+\varepsilon_F+\varepsilon_g.
 \]
 
 Since
@@ -108,17 +114,17 @@ Since
 the triangle inequality gives
 
 \[
-|\widehat a(t^\star)+g|
+|\widehat a(t^\star)+g_{\mathrm{cert}}|
 \le
-\varepsilon_{\mathrm{meas}}+\varepsilon_F.
+\varepsilon_{\mathrm{meas}}+\varepsilon_F+\varepsilon_g.
 \]
 
 Thus
 
 \[
-|\widehat a(t^\star)+g|
+|\widehat a(t^\star)+g_{\mathrm{cert}}|
 >
-\varepsilon_{\mathrm{meas}}+\varepsilon_F
+\varepsilon_{\mathrm{meas}}+\varepsilon_F+\varepsilon_g
 \]
 
 contradicts \(H_0\).
@@ -126,9 +132,9 @@ contradicts \(H_0\).
 Under \(H_1\),
 
 \[
-\widehat a(t^\star)+g
+\widehat a(t^\star)+g_{\mathrm{cert}}
 =
--(g_{\mathrm{eff}}-g)
+-(g_{\mathrm{eff}}-g_{\mathrm{true}})+(g_{\mathrm{cert}}-g_{\mathrm{true}})
 +
 \frac{F_{\mathrm{non\text{-}gravity}}(t^\star)}{m}
 +
@@ -144,21 +150,23 @@ where
 Hence
 
 \[
-|g_{\mathrm{eff}}-g|
+|g_{\mathrm{eff}}-g_{\mathrm{true}}|
 \ge
-|\widehat a(t^\star)+g|
+|\widehat a(t^\star)+g_{\mathrm{cert}}|
 -
 \varepsilon_{\mathrm{meas}}
 -
-\varepsilon_F.
+\varepsilon_F
+-
+\varepsilon_g.
 \]
 
 ## Weakest sufficient threshold
 
-Using only the bounds \(\varepsilon_{\mathrm{meas}}\) and \(\varepsilon_F\), the sharp rejection threshold is
+Using only the bounds \(\varepsilon_{\mathrm{meas}}\), \(\varepsilon_F\), and \(\varepsilon_g\), the sharp rejection threshold is
 
 \[
-\varepsilon_{\mathrm{meas}}+\varepsilon_F.
+\varepsilon_{\mathrm{meas}}+\varepsilon_F+\varepsilon_g.
 \]
 
 Any smaller threshold can falsely reject an \(H_0\)-consistent trajectory.

--- a/tests/test_vtd_trajectory_anomaly_certificate.py
+++ b/tests/test_vtd_trajectory_anomaly_certificate.py
@@ -18,7 +18,7 @@ def test_vtd_doc_boundary_is_conditional():
 
 def test_vtd_doc_has_sharp_threshold():
     text = DOC.read_text()
-    assert r"\varepsilon_{\mathrm{meas}}+\varepsilon_F" in text
+    assert r"\varepsilon_{\mathrm{meas}}+\varepsilon_F+\varepsilon_g" in text
     assert "sharp rejection threshold" in text
 
 def test_vtd_tool_preserves_claim_boundary():
@@ -27,3 +27,4 @@ def test_vtd_tool_preserves_claim_boundary():
     assert "physical anti-gravity mechanism not identified" in text
     assert "H0_REJECTED" in text
     assert "H0_NOT_REJECTED" in text
+    assert "eps_g" in text

--- a/tests/test_vtd_verifier_runtime.py
+++ b/tests/test_vtd_verifier_runtime.py
@@ -16,6 +16,7 @@ def run_vtd(name: str) -> str:
             "--g", "9.8056422",
             "--eps-meas", "0.005",
             "--eps-F", "0.001",
+            "--eps-g", "0.00000005",
             "--window", "31",
             "--degree", "4",
             "--quiet",
@@ -34,7 +35,7 @@ def test_synthetic_ordinary_freefall_does_not_reject_h0():
 def test_synthetic_anomalous_freefall_rejects_h0():
     out = run_vtd("anomalous_freefall_synthetic.csv")
     assert "decision = H0_REJECTED" in out
-    assert "trajectory anomaly certified under supplied bounds" in out
+    assert "trajectory anomaly certified under supplied measurement, force, and gravity-reference bounds" in out
     assert "physical anti-gravity mechanism not identified" in out
 
 def test_synthetic_fixture_boundary_labels():

--- a/tools/vtd_verify.py
+++ b/tools/vtd_verify.py
@@ -3,14 +3,14 @@
 VTD Anti-Gravity Certificate Verifier.
 
 Certificate tested:
-    |a_hat(t*) + g| > eps_meas + eps_F
+    |a_hat(t*) + g_cert| > eps_meas + eps_F + eps_g
 
 If the supplied certificates are valid, this falsifies
     H0: z''(t*) = -g + F_non_gravity(t*)/m,
         |F_non_gravity(t*)|/m <= eps_F,
 
 and certifies the lower bound
-    |g_eff - g| >= |a_hat(t*) + g| - eps_meas - eps_F > 0.
+    |g_eff - g_true| >= |a_hat(t*) + g_cert| - eps_meas - eps_F - eps_g > 0.
 
 Boundary:
     This verifier certifies a trajectory anomaly relative to ordinary force
@@ -162,6 +162,7 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("csv", help="CSV with columns t,z in SI units")
     ap.add_argument("--m", type=float, required=True, help="mass in kg")
     ap.add_argument("--g", type=float, required=True, help="certified local gravitational acceleration in m/s^2")
+    ap.add_argument("--eps-g", type=float, default=0.0, help="certified |g_cert-g_true| bound in m/s^2")
     ap.add_argument("--eps-meas", type=float, required=True, help="certified |a_hat-a_true| bound in m/s^2")
     ap.add_argument("--eps-F", type=float, required=True, help="certified |F_non_gravity|/m bound in m/s^2")
     ap.add_argument("--window", type=int, default=21, help="odd number of samples in each local fit")
@@ -177,6 +178,7 @@ def main() -> int:
 
     require_finite_positive("m", args.m)
     require_finite_positive("g", args.g)
+    require_finite_nonnegative("eps_g", args.eps_g)
     require_finite_nonnegative("eps_meas", args.eps_meas)
     require_finite_nonnegative("eps_F", args.eps_F)
 
@@ -193,7 +195,7 @@ def main() -> int:
         die("not enough samples for the chosen window")
 
     indices = evaluation_indices(t, args.window, args.index, args.time)
-    threshold = args.eps_meas + args.eps_F
+    threshold = args.eps_meas + args.eps_F + args.eps_g
     rows: list[EvalRow] = []
 
     for idx in indices:
@@ -208,7 +210,7 @@ def main() -> int:
     if not args.quiet:
         print(f"# VTD verifier: {Path(args.csv).name}")
         print(f"# evaluated_points = {len(rows)}")
-        print(f"# threshold = eps_meas + eps_F = {threshold:.12g} m/s^2")
+        print(f"# threshold = eps_meas + eps_F + eps_g = {threshold:.12g} m/s^2")
         if len(rows) > 1:
             print("# scan mode: eps_meas and eps_F must be valid uniformly over all evaluated points")
         print("idx,t*,a_hat,abs(a_hat+g),margin,certified,cond")
@@ -230,7 +232,7 @@ def main() -> int:
     if any_cert:
         print("decision = H0_REJECTED")
         print(f"certified_lower_bound_abs_g_eff_minus_g_m_s2 = {best.margin:.12g}")
-        print("claim_boundary = trajectory anomaly certified under supplied bounds; physical anti-gravity mechanism not identified")
+        print("claim_boundary = trajectory anomaly certified under supplied measurement, force, and gravity-reference bounds; physical anti-gravity mechanism not identified")
     else:
         print("decision = H0_NOT_REJECTED")
         print("certified_lower_bound_abs_g_eff_minus_g_m_s2 = 0")


### PR DESCRIPTION
Adds explicit gravity-reference uncertainty eps_g to the VTD theorem, verifier, and runtime tests.

Verified:
- python3 -m py_compile tools/vtd_verify.py
- python3 -m pytest -q tests/test_vtd_trajectory_anomaly_certificate.py tests/test_vtd_verifier_runtime.py

Boundary:
This remains a conditional trajectory-anomaly certificate under supplied measurement, force, and gravity-reference bounds.
It does not identify a physical anti-gravity mechanism.
It is not a theorem-level URF closure claim.