### PR TITLE
docs(vtd): add gravity certificate input stub

### DIFF
--- a/VTD_MECHANISM_PACKET/g_certificate_real.yml
+++ b/VTD_MECHANISM_PACKET/g_certificate_real.yml
@@ -1,0 +1,26 @@
+source_class: "IBGE BDG / Rede Gravimetrica"
+station_type: "Estacao Gravimetrica - EG"
+station_or_site: null
+location_name: "Belo Horizonte, MG"
+latitude_deg: null
+longitude_deg: null
+altitude_m: null
+gravity_mgal: null
+g_cert_m_s2: null
+eps_g_m_s2: null
+conversion:
+  input_unit: "mGal"
+  rule: "g_cert_m_s2 = gravity_mgal * 1.0e-5"
+traceability:
+  station_report_url: null
+  station_report_local_file: null
+  measurement_date: null
+  instrument: null
+  source_agency: "IBGE - Banco de Dados Geodesicos"
+boundary:
+  claim: "gravity-reference certificate only"
+  not_claimed:
+    - "trajectory anomaly certified"
+    - "anti-gravity mechanism proven"
+    - "physical anti-gravity mechanism identified"
+    - "theorem-level URF closure"

--- a/tests/test_vtd_g_certificate_stub.py
+++ b/tests/test_vtd_g_certificate_stub.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+CERT = Path("VTD_MECHANISM_PACKET/g_certificate_real.yml")
+
+def test_vtd_g_certificate_stub_exists():
+    assert CERT.exists()
+
+def test_vtd_g_certificate_stub_has_required_fields():
+    text = CERT.read_text()
+    assert 'source_class: "IBGE BDG / Rede Gravimetrica"' in text
+    assert 'station_type: "Estacao Gravimetrica - EG"' in text
+    assert "station_or_site: null" in text
+    assert "gravity_mgal: null" in text
+    assert "g_cert_m_s2: null" in text
+    assert "eps_g_m_s2: null" in text
+    assert "g_cert_m_s2 = gravity_mgal * 1.0e-5" in text
+
+def test_vtd_g_certificate_stub_preserves_boundary():
+    text = CERT.read_text()
+    assert "gravity-reference certificate only" in text
+    assert "trajectory anomaly certified" in text
+    assert "anti-gravity mechanism proven" in text
+    assert "physical anti-gravity mechanism identified" in text
+    assert "theorem-level URF closure" in text


### PR DESCRIPTION
Adds a guarded VTD gravity-certificate input stub for the real mechanism packet.

Verified:
- python3 -m py_compile tools/vtd_verify.py tools/vtd_mechanism_verify.py
- python3 -m pytest -q tests/test_vtd_trajectory_anomaly_certificate.py tests/test_vtd_verifier_runtime.py tests/test_vtd_real_packet_template.py tests/test_vtd_mechanism_packet_template.py tests/test_vtd_mechanism_verifier_runtime.py tests/test_vtd_mechanism_input_stub.py tests/test_vtd_g_certificate_stub.py

Boundary:
This adds a gravity-certificate stub only.
The numeric gravity and uncertainty fields remain null.
It does not certify a trajectory anomaly.
It does not prove an anti-gravity mechanism.
It does not identify a physical anti-gravity mechanism.
It is not a theorem-level URF closure claim.