### PR TITLE
docs(vtd): complete mechanism input surface stubs

### DIFF
--- a/VTD_MECHANISM_PACKET/control_schedule_u_real.csv
+++ b/VTD_MECHANISM_PACKET/control_schedule_u_real.csv
@@ -1,0 +1,4 @@
+# STUB_ONLY: contains no real empirical VTD control data.
+# Replace this file with measured control schedule samples.
+# Required columns after replacement:
+t,u

--- a/VTD_MECHANISM_PACKET/eps_F_budget_real.csv
+++ b/VTD_MECHANISM_PACKET/eps_F_budget_real.csv
@@ -1,0 +1,10 @@
+channel,bound_m_s2,method,evidence,status
+residual_drag,null,null,null,STUB_ONLY
+vibration,null,null,null,STUB_ONLY
+acoustic,null,null,null,STUB_ONLY
+electrostatic,null,null,null,STUB_ONLY
+magnetic,null,null,null,STUB_ONLY
+thermal,null,null,null,STUB_ONLY
+cable_or_contact,null,null,null,STUB_ONLY
+recoil_or_actuator_coupling,null,null,null,STUB_ONLY
+optical_or_radiation_pressure,null,null,null,STUB_ONLY

--- a/VTD_MECHANISM_PACKET/eps_meas_certificate_real.yml
+++ b/VTD_MECHANISM_PACKET/eps_meas_certificate_real.yml
@@ -1,0 +1,21 @@
+source_class: "measurement-error certificate"
+status: "STUB_ONLY"
+contains_real_empirical_data: false
+estimator: null
+sensor: null
+sampling_rate_hz: null
+fit_window: null
+fit_degree: null
+eps_meas_m_s2: null
+calibration_record: null
+traceability:
+  method: null
+  measurement_date: null
+  operator: null
+boundary:
+  claim: "acceleration-estimator uncertainty certificate only"
+  not_claimed:
+    - "trajectory anomaly certified"
+    - "anti-gravity mechanism proven"
+    - "physical anti-gravity mechanism identified"
+    - "theorem-level URF closure"

--- a/VTD_MECHANISM_PACKET/mechanism_off_real_001.csv
+++ b/VTD_MECHANISM_PACKET/mechanism_off_real_001.csv
@@ -1,0 +1,4 @@
+# STUB_ONLY: contains no real empirical VTD data.
+# Replace this file with measured OFF trajectory samples.
+# Required columns after replacement:
+t,z

--- a/VTD_MECHANISM_PACKET/mechanism_on_real_001.csv
+++ b/VTD_MECHANISM_PACKET/mechanism_on_real_001.csv
@@ -1,0 +1,4 @@
+# STUB_ONLY: contains no real empirical VTD data.
+# Replace this file with measured ON trajectory samples.
+# Required columns after replacement:
+t,z

--- a/VTD_MECHANISM_PACKET/protocol_on_off_real.md
+++ b/VTD_MECHANISM_PACKET/protocol_on_off_real.md
@@ -1,0 +1,30 @@
+# VTD ON/OFF Protocol Stub
+
+Status: STUB_ONLY.
+
+This file contains no real empirical VTD mechanism protocol.
+
+It does not certify a trajectory anomaly.
+
+It does not prove an anti-gravity mechanism.
+
+It does not identify a physical anti-gravity mechanism.
+
+It is not a theorem-level URF closure claim.
+
+## Required replacement content
+
+- Apparatus description
+- Vacuum-path description
+- Sensor/timing calibration
+- OFF run procedure
+- ON run procedure
+- Control schedule procedure
+- Environmental logging procedure
+- Non-gravitational force-budget procedure
+- Blind replication procedure
+- Data-retention procedure
+
+## Completion condition
+
+Replace this stub with a real signed or otherwise traceable protocol record before claiming a real VTD mechanism packet.

--- a/tests/test_vtd_complete_input_surface.py
+++ b/tests/test_vtd_complete_input_surface.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+ROOT = Path("VTD_MECHANISM_PACKET")
+
+REQUIRED = [
+    "README_BOUNDARY.md",
+    "g_certificate_real.yml",
+    "eps_meas_certificate_real.yml",
+    "eps_F_budget_real.csv",
+    "mechanism_off_real_001.csv",
+    "mechanism_on_real_001.csv",
+    "control_schedule_u_real.csv",
+    "protocol_on_off_real.md",
+]
+
+def test_vtd_complete_input_surface_files_exist():
+    for name in REQUIRED:
+        assert (ROOT / name).exists(), name
+    assert (ROOT / "calibration_records").is_dir()
+    assert (ROOT / "environment_logs").is_dir()
+    assert (ROOT / "blinded_replication").is_dir()
+
+def test_vtd_trajectory_and_control_stubs_are_not_empirical():
+    for name in [
+        "mechanism_off_real_001.csv",
+        "mechanism_on_real_001.csv",
+        "control_schedule_u_real.csv",
+    ]:
+        text = (ROOT / name).read_text()
+        assert "STUB_ONLY" in text
+        assert "contains no real empirical VTD" in text
+
+def test_vtd_eps_meas_stub_is_guarded():
+    text = (ROOT / "eps_meas_certificate_real.yml").read_text()
+    assert 'status: "STUB_ONLY"' in text
+    assert "eps_meas_m_s2: null" in text
+    assert "acceleration-estimator uncertainty certificate only" in text
+    assert "anti-gravity mechanism proven" in text
+
+def test_vtd_eps_f_budget_stub_is_guarded():
+    text = (ROOT / "eps_F_budget_real.csv").read_text()
+    assert "channel,bound_m_s2,method,evidence,status" in text
+    assert "residual_drag,null,null,null,STUB_ONLY" in text
+    assert "magnetic,null,null,null,STUB_ONLY" in text
+    assert "recoil_or_actuator_coupling,null,null,null,STUB_ONLY" in text
+
+def test_vtd_protocol_stub_preserves_boundary():
+    text = (ROOT / "protocol_on_off_real.md").read_text()
+    assert "STUB_ONLY" in text
+    assert "contains no real empirical VTD mechanism protocol" in text
+    assert "does not certify a trajectory anomaly" in text
+    assert "does not prove an anti-gravity mechanism" in text
+    assert "does not identify a physical anti-gravity mechanism" in text
+    assert "not a theorem-level URF closure claim" in text
+    assert "anti-gravity mechanism proven." not in text


### PR DESCRIPTION
Completes the repository-side VTD mechanism input surface by adding guarded stubs for OFF trajectory, ON trajectory, control schedule, measurement-error certificate, force-budget certificate, and ON/OFF protocol.

Verified:
- python3 -m py_compile tools/vtd_verify.py tools/vtd_mechanism_verify.py
- python3 -m pytest -q tests/test_vtd_trajectory_anomaly_certificate.py tests/test_vtd_verifier_runtime.py tests/test_vtd_real_packet_template.py tests/test_vtd_mechanism_packet_template.py tests/test_vtd_mechanism_verifier_runtime.py tests/test_vtd_mechanism_input_stub.py tests/test_vtd_g_certificate_stub.py tests/test_vtd_complete_input_surface.py

Boundary:
This completes only the repository-side input surface.
All newly added packet files are stubs.
They contain no real empirical VTD mechanism data.
They do not certify a trajectory anomaly.
They do not prove an anti-gravity mechanism.
They do not identify a physical anti-gravity mechanism.
They are not a theorem-level URF closure claim.