### PR TITLE
tools(vtd): add real packet readiness gate

### DIFF
--- a/tests/test_vtd_packet_readiness_gate.py
+++ b/tests/test_vtd_packet_readiness_gate.py
@@ -1,0 +1,28 @@
+import subprocess
+import sys
+from pathlib import Path
+
+TOOL = Path("tools/vtd_packet_readiness.py")
+
+def test_vtd_packet_readiness_tool_exists():
+    assert TOOL.exists()
+
+def test_vtd_packet_readiness_rejects_stub_packet():
+    proc = subprocess.run(
+        [sys.executable, str(TOOL)],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 1
+    assert "vtd_packet_readiness = NOT_READY" in proc.stdout
+    assert "STUB_ONLY" in proc.stdout
+    assert "real empirical packet not yet admissible" in proc.stdout
+
+def test_vtd_packet_readiness_preserves_boundary():
+    text = TOOL.read_text()
+    assert "does not certify a trajectory anomaly" in text
+    assert "does not prove an anti-gravity mechanism" in text
+    assert "does not identify a physical anti-gravity mechanism" in text
+    assert "not a theorem-level URF closure claim" in text
+    assert "anti-gravity mechanism proven" not in text

--- a/tools/vtd_packet_readiness.py
+++ b/tools/vtd_packet_readiness.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+VTD real-packet readiness gate.
+
+This gate verifies that the VTD_MECHANISM_PACKET input surface has been
+replaced by real packet content before a mechanism-level verifier run is
+treated as admissible.
+
+Boundary:
+    This tool does not certify a trajectory anomaly.
+    This tool does not prove an anti-gravity mechanism.
+    This tool does not identify a physical anti-gravity mechanism.
+    This tool is not a theorem-level URF closure claim.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path("VTD_MECHANISM_PACKET")
+
+REQUIRED_FILES = [
+    "mechanism_off_real_001.csv",
+    "mechanism_on_real_001.csv",
+    "control_schedule_u_real.csv",
+    "g_certificate_real.yml",
+    "eps_meas_certificate_real.yml",
+    "eps_F_budget_real.csv",
+    "protocol_on_off_real.md",
+]
+
+REQUIRED_DIRS = [
+    "calibration_records",
+    "environment_logs",
+    "blinded_replication",
+]
+
+
+def fail(msgs: list[str]) -> int:
+    print("vtd_packet_readiness = NOT_READY")
+    for msg in msgs:
+        print(f"missing_or_stub = {msg}")
+    print("claim_boundary = real empirical packet not yet admissible")
+    return 1
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    if not ROOT.exists():
+        return fail(["VTD_MECHANISM_PACKET directory missing"])
+
+    for name in REQUIRED_FILES:
+        path = ROOT / name
+        if not path.exists():
+            errors.append(f"{name} missing")
+            continue
+        text = path.read_text(errors="replace")
+        if "STUB_ONLY" in text:
+            errors.append(f"{name} still contains STUB_ONLY")
+        if "contains no real empirical VTD" in text:
+            errors.append(f"{name} declares no real empirical VTD data")
+
+    for name in REQUIRED_DIRS:
+        path = ROOT / name
+        if not path.is_dir():
+            errors.append(f"{name}/ missing")
+        elif not any(p.name != ".gitkeep" for p in path.iterdir()):
+            errors.append(f"{name}/ contains no real records")
+
+    g_cert = ROOT / "g_certificate_real.yml"
+    if g_cert.exists():
+        text = g_cert.read_text(errors="replace")
+        for key in ["station_or_site", "gravity_mgal", "g_cert_m_s2", "eps_g_m_s2"]:
+            if f"{key}: null" in text:
+                errors.append(f"g_certificate_real.yml has null {key}")
+
+    eps_meas = ROOT / "eps_meas_certificate_real.yml"
+    if eps_meas.exists():
+        text = eps_meas.read_text(errors="replace")
+        if "eps_meas_m_s2: null" in text:
+            errors.append("eps_meas_certificate_real.yml has null eps_meas_m_s2")
+        if "contains_real_empirical_data: false" in text:
+            errors.append("eps_meas_certificate_real.yml declares contains_real_empirical_data false")
+
+    eps_f = ROOT / "eps_F_budget_real.csv"
+    if eps_f.exists():
+        text = eps_f.read_text(errors="replace")
+        if ",null," in text or ",null\n" in text:
+            errors.append("eps_F_budget_real.csv contains null force-budget entries")
+
+    if errors:
+        return fail(errors)
+
+    print("vtd_packet_readiness = READY")
+    print("claim_boundary = packet readiness only; physical anti-gravity mechanism not identified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a VTD real-packet readiness gate that rejects STUB_ONLY/null mechanism-packet inputs before any real empirical claim can be treated as admissible.

Verified:
- python3 -m py_compile tools/vtd_verify.py tools/vtd_mechanism_verify.py tools/vtd_packet_readiness.py
- python3 -m pytest -q tests/test_vtd_trajectory_anomaly_certificate.py tests/test_vtd_verifier_runtime.py tests/test_vtd_real_packet_template.py tests/test_vtd_mechanism_packet_template.py tests/test_vtd_mechanism_verifier_runtime.py tests/test_vtd_mechanism_input_stub.py tests/test_vtd_g_certificate_stub.py tests/test_vtd_complete_input_surface.py tests/test_vtd_packet_readiness_gate.py

Boundary:
This adds a readiness gate only.
It rejects the current stub packet as not ready.
It does not certify a trajectory anomaly.
It does not prove an anti-gravity mechanism.
It does not identify a physical anti-gravity mechanism.
It is not a theorem-level URF closure claim.