### PR TITLE
docs(vtd): lock empirical gap after readiness gate

### DIFF
--- a/docs/status/VTD_EMPIRICAL_GAP_LOCK_2026_04_30.md
+++ b/docs/status/VTD_EMPIRICAL_GAP_LOCK_2026_04_30.md
@@ -1,0 +1,77 @@
+# VTD Empirical Gap Lock — 2026-04-30
+
+Status: repository-side preparation complete.
+
+This document locks the remaining VTD obstruction as empirical, not mathematical and not repository-infrastructural.
+
+## Completed repository-side layers
+
+- VTD trajectory-anomaly certificate
+- VTD trajectory verifier
+- synthetic trajectory fixtures
+- gravity-reference uncertainty parameter
+- real packet template
+- mechanism packet template
+- ON/OFF mechanism-pattern verifier
+- mechanism input stub
+- gravity-certificate input stub
+- complete mechanism input surface stubs
+- real-packet readiness gate
+
+## Current readiness result
+
+The current packet is expected to fail readiness:
+
+```text
+vtd_packet_readiness = NOT_READY
+This is correct because the packet contains STUB_ONLY and null fields.
+Unique remaining object
+The unique remaining object is a real empirical ON/OFF VTD mechanism packet replacing all stubs:
+VTD_MECHANISM_PACKET/
+  mechanism_off_real_001.csv
+  mechanism_on_real_001.csv
+  control_schedule_u_real.csv
+  g_certificate_real.yml
+  eps_meas_certificate_real.yml
+  eps_F_budget_real.csv
+  protocol_on_off_real.md
+  calibration_records/
+  environment_logs/
+  blinded_replication/
+Required replacement condition
+All of the following must be real, measured, and traceable:
+OFF trajectory data.
+ON trajectory data.
+control schedule.
+local gravity certificate.
+acceleration-estimator uncertainty certificate.
+non-gravitational force budget.
+ON/OFF protocol.
+calibration records.
+environment logs.
+blinded replication records.
+Required gate sequence
+A real packet must pass:
+python3 tools/vtd_packet_readiness.py
+python3 tools/vtd_mechanism_verify.py \
+  --off VTD_MECHANISM_PACKET/mechanism_off_real_001.csv \
+  --on VTD_MECHANISM_PACKET/mechanism_on_real_001.csv \
+  --control VTD_MECHANISM_PACKET/control_schedule_u_real.csv \
+  --m REAL_MASS_KG \
+  --g REAL_G_CERT \
+  --eps-meas REAL_EPS_MEAS \
+  --eps-F REAL_EPS_F \
+  --eps-g REAL_EPS_G \
+  --window 31 \
+  --degree 4
+Success condition
+vtd_packet_readiness = READY
+mechanism_packet_decision = ON_OFF_ANOMALY_PATTERN_CERTIFIED
+Boundary
+This lock does not certify a trajectory anomaly.
+This lock does not prove an anti-gravity mechanism.
+This lock does not identify a physical anti-gravity mechanism.
+This lock is not a theorem-level URF closure claim.
+Terminal statement
+No further repository-side object is required before real empirical ON/OFF VTD input.
+No further progress possible without replacing the stubs with real measured data and independent certificates.

--- a/tests/test_vtd_empirical_gap_lock.py
+++ b/tests/test_vtd_empirical_gap_lock.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+DOC = Path("docs/status/VTD_EMPIRICAL_GAP_LOCK_2026_04_30.md")
+
+def test_vtd_empirical_gap_lock_exists():
+    assert DOC.exists()
+
+def test_vtd_empirical_gap_lock_lists_completed_layers():
+    text = DOC.read_text()
+    assert "VTD trajectory-anomaly certificate" in text
+    assert "VTD trajectory verifier" in text
+    assert "ON/OFF mechanism-pattern verifier" in text
+    assert "real-packet readiness gate" in text
+
+def test_vtd_empirical_gap_lock_names_unique_remaining_object():
+    text = DOC.read_text()
+    assert "unique remaining object is a real empirical ON/OFF VTD mechanism packet" in text
+    assert "mechanism_off_real_001.csv" in text
+    assert "mechanism_on_real_001.csv" in text
+    assert "control_schedule_u_real.csv" in text
+    assert "g_certificate_real.yml" in text
+    assert "eps_meas_certificate_real.yml" in text
+    assert "eps_F_budget_real.csv" in text
+    assert "protocol_on_off_real.md" in text
+    assert "blinded_replication" in text
+
+def test_vtd_empirical_gap_lock_preserves_boundary():
+    text = DOC.read_text()
+    assert "does not certify a trajectory anomaly" in text
+    assert "does not prove an anti-gravity mechanism" in text
+    assert "does not identify a physical anti-gravity mechanism" in text
+    assert "not a theorem-level URF closure claim" in text
+    assert "No further progress possible without replacing the stubs" in text
+    assert "anti-gravity mechanism proven" not in text


### PR DESCRIPTION
Locks the remaining VTD obstruction as the real empirical ON/OFF packet after repository-side readiness-gate completion.

Verified:
- python3 -m py_compile tools/vtd_verify.py tools/vtd_mechanism_verify.py tools/vtd_packet_readiness.py
- python3 -m pytest -q tests/test_vtd_trajectory_anomaly_certificate.py tests/test_vtd_verifier_runtime.py tests/test_vtd_real_packet_template.py tests/test_vtd_mechanism_packet_template.py tests/test_vtd_mechanism_verifier_runtime.py tests/test_vtd_mechanism_input_stub.py tests/test_vtd_g_certificate_stub.py tests/test_vtd_complete_input_surface.py tests/test_vtd_packet_readiness_gate.py tests/test_vtd_empirical_gap_lock.py
- python3 tools/vtd_packet_readiness.py returns NOT_READY for current stubs

Boundary:
This is a status lock only.
It does not certify a trajectory anomaly.
It does not prove an anti-gravity mechanism.
It does not identify a physical anti-gravity mechanism.
It is not a theorem-level URF closure claim.