### PR TITLE
docs(essay): add finite-capacity source audit

### DIFF
--- a/docs/essays/GRF_2026_FINITE_CAPACITY_SOURCE_AUDIT.md
+++ b/docs/essays/GRF_2026_FINITE_CAPACITY_SOURCE_AUDIT.md
@@ -1,0 +1,188 @@
+# Source Audit — Finite-Capacity Spacetime Deflection Essay
+
+## Status
+
+Evidence-support audit for the GRF-style finite-capacity spacetime-deflection essay.
+
+This document supports a conceptual essay artifact.  
+It does not claim theorem-level gravitational closure.
+
+## Claim-support map
+
+### 1. Optical metrics are legitimate effective-geometric objects
+
+**Supported claim.**  
+Optical media can be represented by effective metrics for light propagation in the geometrical-optics regime.
+
+**Primary source.**  
+W. Gordon, “Zur Lichtfortpflanzung nach der Relativitätstheorie,” Annalen der Physik 72, 421–456 (1923).  
+Accessible translation: https://www.neo-classical-physics.info/uploads/3/4/3/6/34363841/gordon_-_optical_metrics.pdf
+
+**Use in essay.**  
+Supports the statement that optical metrics provide exact analogue geometries for null-ray propagation.
+
+**Boundary.**  
+This supports analogue null-geodesic behavior, not full Einstein-matter realization.
+
+---
+
+### 2. Analogue gravity is an established research program
+
+**Supported claim.**  
+Analogue gravity studies general-relativistic effective fields in non-gravitational physical systems.
+
+**Source.**  
+C. Barceló, S. Liberati, and M. Visser, “Analogue Gravity,” Living Reviews in Relativity 14, 3 (2011).  
+https://link.springer.com/article/10.12942/lrr-2011-3
+
+**Use in essay.**  
+Supports the legitimacy of using optical/analogue systems as filters for geometric effects.
+
+**Boundary.**  
+Analogue gravity does not imply that every analogue geometry is sourced by physically admissible gravitational stress-energy.
+
+---
+
+### 3. Transformation optics supports geometry-of-light engineering
+
+**Supported claim.**  
+Transformation optics uses designed media to control electromagnetic propagation through effective geometric structures.
+
+**Source.**  
+U. Leonhardt and T. G. Philbin, “Transformation Optics and the Geometry of Light,” Progress in Optics 53, 69–152 (2009).  
+https://arxiv.org/abs/0805.4778
+
+**Use in essay.**  
+Supports the idea that optical profiles can encode controlled effective geometries.
+
+**Boundary.**  
+Transformation optics is an electromagnetic-engineering framework, not a direct construction of spacetime stress-energy.
+
+---
+
+### 4. Graded-index optics provides bounded refractive-index examples
+
+**Supported claim.**  
+Smooth graded refractive-index profiles are standard physical optical objects.
+
+**Source.**  
+M. D. Feit and J. A. Fleck, “Light propagation in graded-index optical fibers,” Applied Optics 17, 3990–3998 (1978).  
+https://opg.optica.org/abstract.cfm?uri=ao-17-24-3990
+
+**Use in essay.**  
+Supports the bounded example \(n(r)=1-\varepsilon e^{-r/R}\) as an idealized graded-index profile.
+
+**Boundary.**  
+The cited source supports graded-index propagation, not the exact proposed radial profile as a manufactured device.
+
+---
+
+### 5. Energy conditions are admissibility filters, not absolute bans on all apparent repulsion
+
+**Supported claim.**  
+Classical pointwise energy conditions are physically motivated restrictions, but they face known limitations in quantum and semiclassical settings.
+
+**Source.**  
+E.-A. Kontou and K. Sanders, “Energy conditions in general relativity and quantum field theory,” Classical and Quantum Gravity 37, 193001 (2020).  
+https://arxiv.org/abs/2003.01815
+
+**Use in essay.**  
+Supports the distinction between material energy-condition filters and operational finite-capacity filters.
+
+**Boundary.**  
+This does not prove finite capacity as a standard replacement for energy conditions.
+
+---
+
+### 6. Quantum focusing supports the modern information/geometry direction
+
+**Supported claim.**  
+Modern semiclassical gravity relates focusing, entropy, and stress-energy through information-theoretic inequalities.
+
+**Source.**  
+R. Bousso, Z. Fisher, S. Leichenauer, and A. C. Wall, “Quantum focusing conjecture,” Physical Review D 93, 064044 (2016).  
+https://link.aps.org/doi/10.1103/PhysRevD.93.064044
+
+**Use in essay.**  
+Supports the claim that information constraints are central in modern semiclassical gravity.
+
+**Boundary.**  
+QFC does not directly imply the finite-capacity principle.
+
+---
+
+### 7. Two-function metric freedom is the correct realization frontier
+
+**Supported claim.**  
+Static spherically symmetric anisotropic solutions require two generating functions rather than one.
+
+**Source.**  
+L. Herrera, J. Ospino, and A. Di Prisco, “All static spherically symmetric anisotropic solutions of Einstein’s equations,” Physical Review D 77, 027502 (2008).  
+https://arxiv.org/abs/0712.0713
+
+**Use in essay frontier note.**  
+Supports replacing the one-function ansatz
+
+\[
+ds^2=-\alpha(r)dt^2+dr^2+r^2d\Omega^2
+\]
+
+with the two-function ansatz
+
+\[
+ds^2=-\alpha(r)dt^2+\beta(r)dr^2+r^2d\Omega^2.
+\]
+
+**Boundary.**  
+This supports the structural need for two functions, not the existence of a bounded \((\alpha,\beta)\) pair satisfying all desired energy conditions.
+
+## Credibility classification
+
+| Claim | Support Level | Status |
+|---|---:|---|
+| Optical metrics encode null-ray effective geometry | High | Supported |
+| Analogue gravity is established | High | Supported |
+| Bounded graded-index profiles are physically meaningful | High | Supported |
+| Finite capacity is a useful admissibility filter | Medium | Essay proposal |
+| One-function ansatz is too rigid | High | Supported by Einstein-tensor obstruction |
+| Two-function ansatz is the correct next frontier | High | Supported |
+| Full Einstein-matter realization under all energy conditions | Low | Open |
+
+## Minimal unresolved object
+
+**Explicit bounded realization pair.**
+
+Find \(\alpha,\beta\in C^2(\Omega)\) such that:
+
+\[
+0<\alpha_{\min}\le\alpha\le\alpha_{\max}<\infty,
+\qquad
+0<\beta_{\min}\le\beta\le\beta_{\max}<\infty,
+\]
+
+\[
+\sup_\Omega
+\left(
+|\nabla\log\alpha|
++
+|\nabla^2\log\alpha|
++
+|\nabla\log\beta|
++
+|\nabla^2\log\beta|
+\right)<\infty,
+\]
+
+\[
+\Phi'(r)<0,
+\qquad
+\Phi=\frac12\log\alpha,
+\]
+
+and the desired energy-condition inequalities hold.
+
+## Boundary statement
+
+The essay is credible as a finite-capacity/analogue-geometry proposal.
+
+It is not yet a full gravitational realization theorem.

--- a/scripts/verify_grf_source_audit.py
+++ b/scripts/verify_grf_source_audit.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+path = Path("docs/essays/GRF_2026_FINITE_CAPACITY_SOURCE_AUDIT.md")
+text = path.read_text(encoding="utf-8")
+
+required = [
+    "Source Audit",
+    "Optical metrics are legitimate effective-geometric objects",
+    "Analogue gravity is an established research program",
+    "Transformation optics supports geometry-of-light engineering",
+    "Graded-index optics provides bounded refractive-index examples",
+    "Energy conditions are admissibility filters",
+    "Quantum focusing supports the modern information/geometry direction",
+    "Two-function metric freedom is the correct realization frontier",
+    "Explicit bounded realization pair",
+    "It is not yet a full gravitational realization theorem",
+]
+
+for token in required:
+    if token not in text:
+        raise SystemExit(f"missing required token: {token}")
+
+urls = [
+    "gordon_-_optical_metrics.pdf",
+    "10.12942/lrr-2011-3",
+    "0805.4778",
+    "ao-17-24-3990",
+    "2003.01815",
+    "10.1103/PhysRevD.93.064044",
+    "0712.0713",
+]
+
+for token in urls:
+    if token not in text:
+        raise SystemExit(f"missing source URL/token: {token}")
+
+forbidden = [
+    "proves finite capacity",
+    "proves repulsive gravity",
+    "solves semiclassical gravity",
+    "full gravitational realization theorem is proved",
+    "all energy conditions are satisfied",
+]
+
+lower = text.lower()
+for token in forbidden:
+    if token in lower:
+        raise SystemExit(f"forbidden overclaim token: {token}")
+
+print("GRF source audit verification OK.")

--- a/tests/test_grf_source_audit.py
+++ b/tests/test_grf_source_audit.py
@@ -1,0 +1,13 @@
+import subprocess
+from pathlib import Path
+
+def test_grf_source_audit_verifier_passes():
+    subprocess.run(
+        ["python3", "scripts/verify_grf_source_audit.py"],
+        check=True,
+    )
+
+def test_grf_source_audit_has_boundary():
+    text = Path("docs/essays/GRF_2026_FINITE_CAPACITY_SOURCE_AUDIT.md").read_text(encoding="utf-8")
+    assert "It is not yet a full gravitational realization theorem" in text
+    assert "full gravitational realization theorem is proved" not in text.lower()


### PR DESCRIPTION
Adds a credible-source audit for the finite-capacity spacetime-deflection essay.

Change:
- Adds a claim-support map for optical metrics, analogue gravity, transformation optics, graded-index optics, energy conditions, quantum focusing, and two-function static metrics.
- Classifies support levels for each claim.
- Isolates the remaining explicit bounded-realization-pair object.
- Adds a verifier and regression test preserving the claim boundary.

Boundary:
- This is an evidence/support audit.
- No full gravitational realization theorem is claimed.
- Finite capacity remains a proposed admissibility filter.
- The explicit bounded alpha/beta realization remains open.

Verification:
- python3 scripts/verify_grf_source_audit.py
- python3 -m pytest -q tests/test_grf_source_audit.py