### PR TITLE
fix(essay): correct radial NEC factor in two-function frontier

### DIFF
--- a/docs/essays/GRF_2026_FINITE_CAPACITY_TWO_FUNCTION_FRONTIER.md
+++ b/docs/essays/GRF_2026_FINITE_CAPACITY_TWO_FUNCTION_FRONTIER.md
@@ -202,7 +202,7 @@ Hence the radial NEC is equivalent to
 \[
 \frac{\beta'}{\beta}
 +
-2\beta\Phi'
+2\Phi'
 \ge0.
 \]
 
@@ -211,7 +211,7 @@ Since outward deflection gives \(\Phi'<0\), radial NEC requires
 \[
 \frac{\beta'}{\beta}
 \ge
--2\beta\Phi'.
+-2\Phi'.
 \]
 
 ## Weakest replacement lemma
@@ -250,7 +250,7 @@ and
 \[
 \frac{\beta'}{\beta}
 +
-2\beta\Phi'
+2\Phi'
 \ge0.
 \]
 

--- a/scripts/verify_grf_two_function_frontier.py
+++ b/scripts/verify_grf_two_function_frontier.py
@@ -15,7 +15,8 @@ required = [
     "8\\pi p_t",
     "\\Phi'(r)<0",
     "\\rho+p_r\\ge0",
-    "\\frac{\\beta'}{\\beta}\n+\n2\\beta\\Phi'\n\\ge0",
+    "\\frac{\\beta'}{\\beta}\n+\n2\\Phi'\n\\ge0",
+    "\\frac{\\beta'}{\\beta}\n\\ge\n-2\\Phi'.",
     "Two-Function Finite-Capacity Realization Lemma",
     "The next missing object is an explicit bounded pair",
 ]


### PR DESCRIPTION
Corrects the radial NEC inequality in the two-function GRF frontier note.

Change:
- Replaces beta'/beta + 2 beta Phi' >= 0 with beta'/beta + 2 Phi' >= 0.
- Updates the required verifier token accordingly.

Boundary:
- This is a formula correction only.
- No explicit alpha/beta realization is added in this PR.
- Full energy-condition closure remains open.

Verification:
- python3 scripts/verify_grf_two_function_frontier.py
- python3 -m pytest -q tests/test_grf_two_function_frontier.py