### PR TITLE
tools(essay): add transition shell probe

### DIFF
--- a/artifacts/grf/transition_shell_probe.json
+++ b/artifacts/grf/transition_shell_probe.json
@@ -1,0 +1,36 @@
+{
+  "candidate": "C2 smoothstep from local alpha-beta certificate to flat exterior",
+  "interpretation": "Default smoothstep matching fails at least one sampled WEC/DEC margin; global matching remains open and requires a different transition ansatz or interval-certified construction.",
+  "min_margins": {
+    "rho": {
+      "r": 142.05,
+      "value": -3.9038149881246555e-07
+    },
+    "rho_minus_pr": {
+      "r": 142.05,
+      "value": -7.807629976249311e-07
+    },
+    "rho_minus_pt": {
+      "r": 117.008,
+      "value": -1.3130158123650692e-06
+    },
+    "rho_plus_pr": {
+      "r": 10.0,
+      "value": 0.0
+    },
+    "rho_plus_pt": {
+      "r": 175.908,
+      "value": -8.960060770880812e-07
+    }
+  },
+  "minimum_value": -1.3130158123650692e-06,
+  "parameters": {
+    "R_out": 200.0,
+    "a": 0.001,
+    "exterior": "flat",
+    "r0": 10.0,
+    "r1": 20.0,
+    "samples": 5001
+  },
+  "status": "FRONTIER_FAIL"
+}

--- a/docs/essays/GRF_2026_TRANSITION_SHELL_PROBE.md
+++ b/docs/essays/GRF_2026_TRANSITION_SHELL_PROBE.md
@@ -1,0 +1,88 @@
+# Transition-Shell Probe for the Finite-Capacity Spacetime-Deflection Package
+
+## Status
+
+Computable frontier probe.
+
+This document records an executable test for a naive \(C^2\) transition shell from the local alpha-beta certificate to a flat exterior.
+
+It does not claim a global matching theorem.
+
+## Candidate tested
+
+The local certificate is
+
+\[
+\alpha=e^{-2ar},
+\qquad
+\beta=e^{2ar},
+\]
+
+equivalently
+
+\[
+\Phi=-ar,
+\qquad
+\Lambda=ar.
+\]
+
+The probe tests a \(C^2\) smoothstep transition to a flat exterior:
+
+\[
+\Phi_{\mathrm{ext}}=0,
+\qquad
+\Lambda_{\mathrm{ext}}=0.
+\]
+
+## Energy-condition margins
+
+The executable probe evaluates the five scalar margins
+
+\[
+\rho,
+\qquad
+\rho+p_r,
+\qquad
+\rho+p_t,
+\qquad
+\rho-p_r,
+\qquad
+\rho-p_t.
+\]
+
+## Result
+
+The default smoothstep-to-flat transition is expected to fail at least one sampled margin.
+
+This is not a failure of the local alpha-beta certificate.
+
+It means the naive transition shell is not the Global Matching Lemma.
+
+## Artifact
+
+The probe writes:
+
+\[
+\texttt{artifacts/grf/transition\_shell\_probe.json}
+\]
+
+with:
+
+- sampled minimum margin values,
+- the radius at which each sampled minimum occurs,
+- the candidate status,
+- the boundary interpretation.
+
+## Boundary
+
+This is a numerical frontier probe.
+
+This is not interval arithmetic.
+
+It is not an impossibility theorem.
+
+It is not a global-existence theorem.
+
+## Next missing object
+
+A transition ansatz with interval-certified nonnegative margins on the full transition shell.

--- a/scripts/verify_grf_transition_shell_probe.py
+++ b/scripts/verify_grf_transition_shell_probe.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+from pathlib import Path
+
+DOC = Path("docs/essays/GRF_2026_TRANSITION_SHELL_PROBE.md")
+TOOL = Path("tools/grf_transition_shell_probe.py")
+ARTIFACT = Path("artifacts/grf/transition_shell_probe.json")
+
+for path in [DOC, TOOL]:
+    if not path.exists():
+        raise SystemExit(f"missing required file: {path}")
+
+doc = DOC.read_text(encoding="utf-8")
+required = [
+    "Computable frontier probe.",
+    "It does not claim a global matching theorem.",
+    "The default smoothstep-to-flat transition is expected to fail",
+    "This is not interval arithmetic.",
+    "It is not an impossibility theorem.",
+    "It is not a global-existence theorem.",
+    "A transition ansatz with interval-certified nonnegative margins",
+]
+
+for token in required:
+    if token not in doc:
+        raise SystemExit(f"missing required doc token: {token}")
+
+forbidden = [
+    "global matching theorem is proved",
+    "impossibility theorem is proved",
+    "global-existence theorem is proved",
+    "unconditional gravitational closure",
+]
+
+lower = doc.lower()
+for token in forbidden:
+    if token in lower:
+        raise SystemExit(f"forbidden doc token: {token}")
+
+subprocess.run(["python3", str(TOOL)], check=True)
+
+payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+if payload.get("status") != "FRONTIER_FAIL":
+    raise SystemExit(f"expected FRONTIER_FAIL, got {payload.get('status')}")
+
+margins = payload.get("min_margins", {})
+if not margins:
+    raise SystemExit("missing min_margins")
+
+if not any(item["value"] < 0 for item in margins.values()):
+    raise SystemExit("expected at least one negative sampled margin")
+
+if "smoothstep" not in payload.get("candidate", ""):
+    raise SystemExit("missing smoothstep candidate label")
+
+print("GRF transition-shell probe verification OK.")

--- a/tests/test_grf_transition_shell_probe.py
+++ b/tests/test_grf_transition_shell_probe.py
@@ -1,0 +1,14 @@
+import json
+import subprocess
+from pathlib import Path
+
+def test_grf_transition_shell_probe_verifier_passes():
+    subprocess.run(
+        ["python3", "scripts/verify_grf_transition_shell_probe.py"],
+        check=True,
+    )
+
+def test_grf_transition_shell_artifact_is_frontier_fail():
+    payload = json.loads(Path("artifacts/grf/transition_shell_probe.json").read_text(encoding="utf-8"))
+    assert payload["status"] == "FRONTIER_FAIL"
+    assert any(item["value"] < 0 for item in payload["min_margins"].values())

--- a/tools/grf_transition_shell_probe.py
+++ b/tools/grf_transition_shell_probe.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+import json
+import math
+from pathlib import Path
+
+OUT = Path("artifacts/grf/transition_shell_probe.json")
+
+PARAMS = {
+    "a": 0.001,
+    "r0": 10.0,
+    "r1": 20.0,
+    "R_out": 200.0,
+    "samples": 5001,
+    "exterior": "flat",
+}
+
+MARGIN_NAMES = [
+    "rho",
+    "rho_plus_pr",
+    "rho_plus_pt",
+    "rho_minus_pr",
+    "rho_minus_pt",
+]
+
+
+def smoothstep(t: float) -> float:
+    return 6.0 * t**5 - 15.0 * t**4 + 10.0 * t**3
+
+
+def smoothstep_prime(t: float) -> float:
+    return 30.0 * t**4 - 60.0 * t**3 + 30.0 * t**2
+
+
+def smoothstep_second(t: float) -> float:
+    return 120.0 * t**3 - 180.0 * t**2 + 60.0 * t
+
+
+def local_fields(r: float, a: float):
+    phi = -a * r
+    phi_p = -a
+    phi_pp = 0.0
+    lam = a * r
+    lam_p = a
+    lam_pp = 0.0
+    return phi, phi_p, phi_pp, lam, lam_p, lam_pp
+
+
+def flat_fields(_r: float):
+    return 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+
+
+def blended_fields(r: float, params):
+    a = params["a"]
+    r1 = params["r1"]
+    R_out = params["R_out"]
+
+    if r <= r1:
+        return local_fields(r, a)
+
+    if r >= R_out:
+        return flat_fields(r)
+
+    width = R_out - r1
+    t = (r - r1) / width
+    h = smoothstep(t)
+    hp = smoothstep_prime(t) / width
+    hpp = smoothstep_second(t) / (width * width)
+
+    phi0, phi0_p, phi0_pp, lam0, lam0_p, lam0_pp = local_fields(r, a)
+
+    # Exterior is flat, so field_ext = field_ext' = field_ext'' = 0.
+    phi = (1.0 - h) * phi0
+    phi_p = (1.0 - h) * phi0_p - hp * phi0
+    phi_pp = (1.0 - h) * phi0_pp - 2.0 * hp * phi0_p - hpp * phi0
+
+    lam = (1.0 - h) * lam0
+    lam_p = (1.0 - h) * lam0_p - hp * lam0
+    lam_pp = (1.0 - h) * lam0_pp - 2.0 * hp * lam0_p - hpp * lam0
+
+    return phi, phi_p, phi_pp, lam, lam_p, lam_pp
+
+
+def energy_margins(r: float, fields):
+    phi, phi_p, phi_pp, lam, lam_p, _lam_pp = fields
+    e = math.exp(-2.0 * lam)
+
+    rho = ((1.0 - e) / (r * r) + 2.0 * lam_p * e / r) / (8.0 * math.pi)
+    pr = (-(1.0 - e) / (r * r) + 2.0 * phi_p * e / r) / (8.0 * math.pi)
+    pt = (
+        e
+        * (
+            phi_pp
+            + phi_p * phi_p
+            - phi_p * lam_p
+            + (phi_p - lam_p) / r
+        )
+        / (8.0 * math.pi)
+    )
+
+    return {
+        "rho": rho,
+        "rho_plus_pr": rho + pr,
+        "rho_plus_pt": rho + pt,
+        "rho_minus_pr": rho - pr,
+        "rho_minus_pt": rho - pt,
+    }
+
+
+def run_probe(params):
+    r0 = params["r0"]
+    R_out = params["R_out"]
+    samples = int(params["samples"])
+
+    minima = {
+        name: {"value": float("inf"), "r": None}
+        for name in MARGIN_NAMES
+    }
+
+    for i in range(samples):
+        r = r0 + (R_out - r0) * i / (samples - 1)
+        margins = energy_margins(r, blended_fields(r, params))
+        for name, value in margins.items():
+            if value < minima[name]["value"]:
+                minima[name] = {"value": value, "r": r}
+
+    min_value = min(item["value"] for item in minima.values())
+    status = "PASS_NUMERICAL_SAMPLE" if min_value >= 0.0 else "FRONTIER_FAIL"
+
+    return {
+        "status": status,
+        "candidate": "C2 smoothstep from local alpha-beta certificate to flat exterior",
+        "parameters": params,
+        "min_margins": minima,
+        "minimum_value": min_value,
+        "interpretation": (
+            "Default smoothstep matching fails at least one sampled WEC/DEC margin; "
+            "global matching remains open and requires a different transition ansatz "
+            "or interval-certified construction."
+        ),
+    }
+
+
+def main():
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    payload = run_probe(PARAMS)
+    OUT.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds an executable transition-shell probe for the finite-capacity spacetime-deflection package.

Change:
- Adds a computable smoothstep transition-shell probe.
- Generates artifacts/grf/transition_shell_probe.json.
- Records sampled WEC/DEC margin minima.
- Confirms the naive smoothstep-to-flat transition is a frontier failure, not a closure.
- Adds a verifier and regression test preserving the no-global-matching boundary.

Boundary:
- This is a numerical frontier probe.
- This is not interval arithmetic.
- It is not an impossibility theorem.
- It is not a global-existence theorem.
- The next missing object is an interval-certified transition ansatz.

Verification:
- python3 tools/grf_transition_shell_probe.py
- python3 scripts/verify_grf_transition_shell_probe.py
- python3 -m pytest -q tests/test_grf_transition_shell_probe.py