### PR TITLE
docs(essay): isolate flat exterior obstruction

### DIFF
--- a/docs/essays/GRF_2026_FLAT_EXTERIOR_OBSTRUCTION.md
+++ b/docs/essays/GRF_2026_FLAT_EXTERIOR_OBSTRUCTION.md
@@ -1,0 +1,212 @@
+# Flat-Exterior Obstruction for the Finite-Capacity Transition Shell
+
+## Status
+
+Conditional structural obstruction.
+
+This document explains why the naive smoothstep-to-flat transition-shell probe fails.
+
+It does not prove global matching.
+
+It identifies the correct replacement exterior.
+
+## Setup
+
+Use the static spherical metric
+
+\[
+ds^2=-e^{2\Phi(r)}dt^2+e^{2\Lambda(r)}dr^2+r^2d\Omega^2.
+\]
+
+Define the Misner-Sharp mass function
+
+\[
+m(r)=\frac r2\left(1-e^{-2\Lambda(r)}\right).
+\]
+
+Then
+
+\[
+m'(r)=4\pi r^2\rho(r).
+\]
+
+Therefore, under the weak energy condition
+
+\[
+\rho\ge0,
+\]
+
+the mass function is monotone nondecreasing:
+
+\[
+m'(r)\ge0.
+\]
+
+## Local certificate mass
+
+The local alpha-beta certificate has
+
+\[
+\alpha=e^{-2ar},
+\qquad
+\beta=e^{2ar},
+\]
+
+so
+
+\[
+\Phi=-ar,
+\qquad
+\Lambda=ar.
+\]
+
+Hence
+
+\[
+m_{\mathrm{loc}}(r)
+=
+\frac r2\left(1-e^{-2ar}\right).
+\]
+
+For every
+
+\[
+a>0,
+\qquad r>0,
+\]
+
+one has
+
+\[
+m_{\mathrm{loc}}(r)>0.
+\]
+
+In particular,
+
+\[
+m_{\mathrm{loc}}(r_1)
+=
+\frac {r_1}2\left(1-e^{-2ar_1}\right)
+>0.
+\]
+
+## Flat exterior obstruction
+
+A flat exterior has
+
+\[
+\Lambda_{\mathrm{flat}}=0,
+\]
+
+so
+
+\[
+m_{\mathrm{flat}}(r)=0.
+\]
+
+If a transition starts from the local certificate at \(r_1\), then
+
+\[
+m(r_1)>0.
+\]
+
+If it ends in a flat exterior, then eventually
+
+\[
+m(r)=0.
+\]
+
+Thus \(m\) must decrease somewhere.
+
+But under \(\rho\ge0\),
+
+\[
+m'(r)=4\pi r^2\rho(r)\ge0.
+\]
+
+Therefore a WEC-preserving transition from the local alpha-beta certificate to a flat exterior cannot exist.
+
+## Interpretation of the numerical probe
+
+The transition-shell probe found negative sampled margins for the naive smoothstep-to-flat candidate.
+
+This is structurally expected: the candidate attempts to reduce positive local mass to zero while preserving WEC/DEC margins.
+
+The failure is not evidence against the local alpha-beta certificate.
+
+It is evidence that flat exterior matching is the wrong target.
+
+## Correct replacement exterior
+
+The exterior target should be Schwarzschild-type with mass
+
+\[
+M\ge m_{\mathrm{loc}}(r_1).
+\]
+
+For Schwarzschild exterior,
+
+\[
+e^{2\Phi_{\mathrm{ext}}}=1-\frac{2M}{r},
+\qquad
+e^{2\Lambda_{\mathrm{ext}}}=
+\left(1-\frac{2M}{r}\right)^{-1},
+\]
+
+and
+
+\[
+m_{\mathrm{ext}}(r)=M.
+\]
+
+This is compatible with monotone mass provided
+
+\[
+M\ge m_{\mathrm{loc}}(r_1).
+\]
+
+## Corrected next frontier
+
+Replace:
+
+\[
+\text{local certificate} \to \text{flat exterior}
+\]
+
+with:
+
+\[
+\text{local certificate} \to \text{positive-mass Schwarzschild exterior}.
+\]
+
+## Boundary
+
+This document proves only the flat-exterior obstruction under \(\rho\ge0\).
+
+It does not construct the Schwarzschild matching shell.
+
+It does not prove global existence.
+
+It does not prove semiclassical stability.
+
+## Next missing object
+
+A computable positive-mass Schwarzschild transition-shell certificate satisfying:
+
+\[
+M\ge m_{\mathrm{loc}}(r_1),
+\]
+
+\[
+\rho\ge0,
+\qquad
+\rho+p_r\ge0,
+\qquad
+\rho+p_t\ge0,
+\qquad
+\rho-p_r\ge0,
+\qquad
+\rho-p_t\ge0
+\]
+
+through the transition shell.

--- a/scripts/verify_grf_flat_exterior_obstruction.py
+++ b/scripts/verify_grf_flat_exterior_obstruction.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+DOC = Path("docs/essays/GRF_2026_FLAT_EXTERIOR_OBSTRUCTION.md")
+text = DOC.read_text(encoding="utf-8")
+
+required = [
+    "Flat-Exterior Obstruction",
+    "Conditional structural obstruction.",
+    "m(r)=\\frac r2\\left(1-e^{-2\\Lambda(r)}\\right)",
+    "m'(r)=4\\pi r^2\\rho(r)",
+    "\\rho\\ge0",
+    "m_{\\mathrm{loc}}(r)>0",
+    "A flat exterior has",
+    "m_{\\mathrm{flat}}(r)=0",
+    "a WEC-preserving transition from the local alpha-beta certificate to a flat exterior cannot exist",
+    "positive-mass Schwarzschild exterior",
+    "M\\ge m_{\\mathrm{loc}}(r_1)",
+    "It does not construct the Schwarzschild matching shell.",
+    "A computable positive-mass Schwarzschild transition-shell certificate",
+]
+
+for token in required:
+    if token not in text:
+        raise SystemExit(f"missing required token: {token}")
+
+forbidden = [
+    "global existence is proved",
+    "semiclassical stability is proved",
+    "schwarzschild matching shell is constructed",
+    "unconditional gravitational closure",
+]
+
+lower = text.lower()
+for token in forbidden:
+    if token in lower:
+        raise SystemExit(f"forbidden token: {token}")
+
+print("GRF flat-exterior obstruction verification OK.")

--- a/tests/test_grf_flat_exterior_obstruction.py
+++ b/tests/test_grf_flat_exterior_obstruction.py
@@ -1,0 +1,14 @@
+import subprocess
+from pathlib import Path
+
+def test_grf_flat_exterior_obstruction_verifier_passes():
+    subprocess.run(
+        ["python3", "scripts/verify_grf_flat_exterior_obstruction.py"],
+        check=True,
+    )
+
+def test_grf_flat_exterior_obstruction_boundary():
+    text = Path("docs/essays/GRF_2026_FLAT_EXTERIOR_OBSTRUCTION.md").read_text(encoding="utf-8")
+    assert "It does not construct the Schwarzschild matching shell." in text
+    assert "A computable positive-mass Schwarzschild transition-shell certificate" in text
+    assert "unconditional gravitational closure" not in text.lower()


### PR DESCRIPTION
Adds the flat-exterior obstruction for the finite-capacity transition-shell package.

Change:
- Explains why the smoothstep-to-flat transition probe fails.
- Introduces the Misner-Sharp mass monotonicity obstruction under rho >= 0.
- Shows flat exterior matching is incompatible with the positive local certificate mass.
- Identifies positive-mass Schwarzschild matching as the corrected exterior target.
- Adds a verifier and regression test preserving the boundary.

Boundary:
- This is a conditional structural obstruction under WEC.
- It does not construct the Schwarzschild matching shell.
- It does not prove global existence.
- It does not prove semiclassical stability.

Verification:
- python3 scripts/verify_grf_flat_exterior_obstruction.py
- python3 -m pytest -q tests/test_grf_flat_exterior_obstruction.py