### PR TITLE
tools(essay): add Schwarzschild transition probe

### DIFF
--- a/artifacts/grf/schwarzschild_transition_probe.json
+++ b/artifacts/grf/schwarzschild_transition_probe.json
@@ -1,0 +1,49 @@
+{
+  "base": {
+    "a": 0.001,
+    "r0": 10.0,
+    "r1": 20.0,
+    "samples": 4001
+  },
+  "best_candidate": {
+    "min_margins": {
+      "rho": {
+        "r": 729.235,
+        "value": -5.343955079561831e-08
+      },
+      "rho_minus_pr": {
+        "r": 729.235,
+        "value": -1.0687910159123662e-07
+      },
+      "rho_minus_pt": {
+        "r": 615.385,
+        "value": -1.7347198197940492e-07
+      },
+      "rho_plus_pr": {
+        "r": 10.0,
+        "value": 0.0
+      },
+      "rho_plus_pt": {
+        "r": 886.3975,
+        "value": -1.3457517909823786e-07
+      }
+    },
+    "minimum_value": -1.7347198197940492e-07,
+    "parameters": {
+      "M": 5.097372910197987,
+      "R_out": 1000.0,
+      "a": 0.001,
+      "exterior": "positive-mass Schwarzschild",
+      "local_mass_at_r1": 0.39210560847676823,
+      "mass_factor": 13.0,
+      "r0": 10.0,
+      "r1": 20.0,
+      "samples": 4001
+    },
+    "status": "FRONTIER_FAIL"
+  },
+  "candidate_count": 70,
+  "interpretation": "Grid search over positive-mass Schwarzschild smoothstep transitions. A PASS_NUMERICAL_SAMPLE is only sampled numerical evidence, not interval proof. A FRONTIER_FAIL means this finite grid found no sampled nonnegative shell.",
+  "next_missing_object": "interval-certified positive-mass Schwarzschild transition ansatz",
+  "status": "FRONTIER_FAIL"
+}

--- a/docs/essays/GRF_2026_SCHWARZSCHILD_TRANSITION_PROBE.md
+++ b/docs/essays/GRF_2026_SCHWARZSCHILD_TRANSITION_PROBE.md
@@ -1,0 +1,75 @@
+# Positive-Mass Schwarzschild Transition Probe
+
+## Status
+
+Computable frontier probe.
+
+This document adds a sampled search probe for matching the local finite-capacity alpha-beta certificate to a positive-mass Schwarzschild exterior.
+
+It does not claim a global matching theorem.
+
+## Motivation
+
+The flat-exterior obstruction shows that matching the local certificate to flat space is incompatible with WEC mass monotonicity.
+
+The corrected exterior target is positive-mass Schwarzschild with
+
+\[
+M\ge m_{\mathrm{loc}}(r_1).
+\]
+
+## Probe
+
+The executable probe searches over finite values of:
+
+\[
+M/m_{\mathrm{loc}}(r_1)
+\]
+
+and transition radii
+
+\[
+R_{\mathrm{out}}.
+\]
+
+For each candidate it samples the five margins
+
+\[
+\rho,
+\qquad
+\rho+p_r,
+\qquad
+\rho+p_t,
+\qquad
+\rho-p_r,
+\qquad
+\rho-p_t.
+\]
+
+## Artifact
+
+The probe writes:
+
+\[
+\texttt{artifacts/grf/schwarzschild\_transition\_probe.json}
+\]
+
+containing:
+
+- candidate count,
+- best sampled candidate,
+- sampled minimum margin values,
+- status,
+- next missing object.
+
+## Boundary
+
+This is a numerical frontier probe.
+
+This is not interval arithmetic.
+
+A sampled pass is not a theorem.
+
+A sampled failure is not an impossibility theorem.
+
+The next missing object remains an interval-certified positive-mass Schwarzschild transition ansatz.

--- a/scripts/verify_grf_schwarzschild_transition_probe.py
+++ b/scripts/verify_grf_schwarzschild_transition_probe.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+from pathlib import Path
+
+DOC = Path("docs/essays/GRF_2026_SCHWARZSCHILD_TRANSITION_PROBE.md")
+TOOL = Path("tools/grf_schwarzschild_transition_probe.py")
+ARTIFACT = Path("artifacts/grf/schwarzschild_transition_probe.json")
+
+for path in [DOC, TOOL]:
+    if not path.exists():
+        raise SystemExit(f"missing required file: {path}")
+
+doc = DOC.read_text(encoding="utf-8")
+required = [
+    "Computable frontier probe.",
+    "It does not claim a global matching theorem.",
+    "positive-mass Schwarzschild",
+    "M\\ge m_{\\mathrm{loc}}(r_1)",
+    "This is not interval arithmetic.",
+    "A sampled pass is not a theorem.",
+    "A sampled failure is not an impossibility theorem.",
+    "interval-certified positive-mass Schwarzschild transition ansatz",
+]
+
+for token in required:
+    if token not in doc:
+        raise SystemExit(f"missing required doc token: {token}")
+
+forbidden = [
+    "global matching theorem is proved",
+    "interval arithmetic certificate is proved",
+    "impossibility theorem is proved",
+    "unconditional gravitational closure",
+]
+
+lower = doc.lower()
+for token in forbidden:
+    if token in lower:
+        raise SystemExit(f"forbidden doc token: {token}")
+
+subprocess.run(["python3", str(TOOL)], check=True)
+
+payload = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+if payload.get("status") not in {"PASS_NUMERICAL_SAMPLE", "FRONTIER_FAIL"}:
+    raise SystemExit(f"unexpected status: {payload.get('status')}")
+
+if payload.get("candidate_count", 0) <= 0:
+    raise SystemExit("candidate_count must be positive")
+
+best = payload.get("best_candidate", {})
+if "min_margins" not in best:
+    raise SystemExit("best candidate missing min_margins")
+
+if payload.get("next_missing_object") != "interval-certified positive-mass Schwarzschild transition ansatz":
+    raise SystemExit("wrong next missing object")
+
+print("GRF Schwarzschild transition probe verification OK.")

--- a/tests/test_grf_schwarzschild_transition_probe.py
+++ b/tests/test_grf_schwarzschild_transition_probe.py
@@ -1,0 +1,14 @@
+import json
+import subprocess
+from pathlib import Path
+
+def test_grf_schwarzschild_transition_probe_verifier_passes():
+    subprocess.run(
+        ["python3", "scripts/verify_grf_schwarzschild_transition_probe.py"],
+        check=True,
+    )
+
+def test_grf_schwarzschild_transition_probe_artifact_boundary():
+    payload = json.loads(Path("artifacts/grf/schwarzschild_transition_probe.json").read_text(encoding="utf-8"))
+    assert payload["status"] in {"PASS_NUMERICAL_SAMPLE", "FRONTIER_FAIL"}
+    assert payload["next_missing_object"] == "interval-certified positive-mass Schwarzschild transition ansatz"

--- a/tools/grf_schwarzschild_transition_probe.py
+++ b/tools/grf_schwarzschild_transition_probe.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+import json
+import math
+from pathlib import Path
+
+OUT = Path("artifacts/grf/schwarzschild_transition_probe.json")
+
+BASE = {
+    "a": 0.001,
+    "r0": 10.0,
+    "r1": 20.0,
+    "samples": 4001,
+}
+
+MARGIN_NAMES = [
+    "rho",
+    "rho_plus_pr",
+    "rho_plus_pt",
+    "rho_minus_pr",
+    "rho_minus_pt",
+]
+
+
+def smoothstep(t: float) -> float:
+    return 6.0 * t**5 - 15.0 * t**4 + 10.0 * t**3
+
+
+def smoothstep_prime(t: float) -> float:
+    return 30.0 * t**4 - 60.0 * t**3 + 30.0 * t**2
+
+
+def smoothstep_second(t: float) -> float:
+    return 120.0 * t**3 - 180.0 * t**2 + 60.0 * t
+
+
+def local_mass(r: float, a: float) -> float:
+    return 0.5 * r * (1.0 - math.exp(-2.0 * a * r))
+
+
+def local_fields(r: float, a: float):
+    return {
+        "phi": -a * r,
+        "phi_p": -a,
+        "phi_pp": 0.0,
+        "lam": a * r,
+        "lam_p": a,
+        "lam_pp": 0.0,
+    }
+
+
+def schwarzschild_fields(r: float, M: float):
+    f = 1.0 - 2.0 * M / r
+    if f <= 0.0:
+        raise ValueError("Schwarzschild exterior evaluated at or inside horizon")
+
+    denom = r * r * f
+    phi = 0.5 * math.log(f)
+    phi_p = M / denom
+    phi_pp = -2.0 * M * (r - M) / (denom * denom)
+
+    lam = -0.5 * math.log(f)
+    lam_p = -M / denom
+    lam_pp = 2.0 * M * (r - M) / (denom * denom)
+
+    return {
+        "phi": phi,
+        "phi_p": phi_p,
+        "phi_pp": phi_pp,
+        "lam": lam,
+        "lam_p": lam_p,
+        "lam_pp": lam_pp,
+    }
+
+
+def blended_fields(r: float, params):
+    a = params["a"]
+    r1 = params["r1"]
+    Rout = params["R_out"]
+    M = params["M"]
+
+    if r <= r1:
+        return local_fields(r, a)
+
+    if r >= Rout:
+        return schwarzschild_fields(r, M)
+
+    width = Rout - r1
+    t = (r - r1) / width
+    h = smoothstep(t)
+    hp = smoothstep_prime(t) / width
+    hpp = smoothstep_second(t) / (width * width)
+
+    L = local_fields(r, a)
+    E = schwarzschild_fields(r, M)
+
+    out = {}
+    for key, deriv1, deriv2 in [
+        ("phi", "phi_p", "phi_pp"),
+        ("lam", "lam_p", "lam_pp"),
+    ]:
+        f0 = L[key]
+        f0p = L[deriv1]
+        f0pp = L[deriv2]
+
+        f1 = E[key]
+        f1p = E[deriv1]
+        f1pp = E[deriv2]
+
+        diff = f1 - f0
+        diffp = f1p - f0p
+        diffpp = f1pp - f0pp
+
+        out[key] = f0 + h * diff
+        out[deriv1] = f0p + hp * diff + h * diffp
+        out[deriv2] = f0pp + hpp * diff + 2.0 * hp * diffp + h * diffpp
+
+    return out
+
+
+def energy_margins(r: float, fields):
+    phi_p = fields["phi_p"]
+    phi_pp = fields["phi_pp"]
+    lam = fields["lam"]
+    lam_p = fields["lam_p"]
+
+    e = math.exp(-2.0 * lam)
+
+    rho = ((1.0 - e) / (r * r) + 2.0 * lam_p * e / r) / (8.0 * math.pi)
+    pr = (-(1.0 - e) / (r * r) + 2.0 * phi_p * e / r) / (8.0 * math.pi)
+    pt = (
+        e
+        * (
+            phi_pp
+            + phi_p * phi_p
+            - phi_p * lam_p
+            + (phi_p - lam_p) / r
+        )
+        / (8.0 * math.pi)
+    )
+
+    return {
+        "rho": rho,
+        "rho_plus_pr": rho + pr,
+        "rho_plus_pt": rho + pt,
+        "rho_minus_pr": rho - pr,
+        "rho_minus_pt": rho - pt,
+    }
+
+
+def evaluate(params):
+    r0 = params["r0"]
+    Rout = params["R_out"]
+    samples = int(params["samples"])
+
+    minima = {name: {"value": float("inf"), "r": None} for name in MARGIN_NAMES}
+
+    for i in range(samples):
+        r = r0 + (Rout - r0) * i / (samples - 1)
+        try:
+            fields = blended_fields(r, params)
+            margins = energy_margins(r, fields)
+        except (ValueError, OverflowError, ZeroDivisionError):
+            return {
+                "status": "INVALID",
+                "parameters": params,
+                "min_margins": minima,
+                "minimum_value": None,
+            }
+
+        for name, value in margins.items():
+            if value < minima[name]["value"]:
+                minima[name] = {"value": value, "r": r}
+
+    min_value = min(item["value"] for item in minima.values())
+    status = "PASS_NUMERICAL_SAMPLE" if min_value >= 0.0 else "FRONTIER_FAIL"
+    return {
+        "status": status,
+        "parameters": params,
+        "min_margins": minima,
+        "minimum_value": min_value,
+    }
+
+
+def run_search():
+    a = BASE["a"]
+    r1 = BASE["r1"]
+    m1 = local_mass(r1, a)
+
+    candidates = []
+    for mass_factor in [1.0, 1.05, 1.1, 1.25, 1.5, 2.0, 3.0, 5.0, 8.0, 13.0]:
+        M = mass_factor * m1
+        for R_out in [50.0, 80.0, 120.0, 200.0, 350.0, 600.0, 1000.0]:
+            if R_out <= max(r1, 2.5 * M):
+                continue
+            params = dict(BASE)
+            params.update(
+                {
+                    "M": M,
+                    "mass_factor": mass_factor,
+                    "R_out": R_out,
+                    "exterior": "positive-mass Schwarzschild",
+                    "local_mass_at_r1": m1,
+                }
+            )
+            candidates.append(evaluate(params))
+
+    valid = [c for c in candidates if c["status"] != "INVALID"]
+    passing = [c for c in valid if c["status"] == "PASS_NUMERICAL_SAMPLE"]
+
+    if passing:
+        best = max(passing, key=lambda c: c["minimum_value"])
+        status = "PASS_NUMERICAL_SAMPLE"
+    else:
+        best = max(valid, key=lambda c: c["minimum_value"])
+        status = "FRONTIER_FAIL"
+
+    return {
+        "status": status,
+        "interpretation": (
+            "Grid search over positive-mass Schwarzschild smoothstep transitions. "
+            "A PASS_NUMERICAL_SAMPLE is only sampled numerical evidence, not interval proof. "
+            "A FRONTIER_FAIL means this finite grid found no sampled nonnegative shell."
+        ),
+        "base": BASE,
+        "candidate_count": len(candidates),
+        "best_candidate": best,
+        "next_missing_object": "interval-certified positive-mass Schwarzschild transition ansatz",
+    }
+
+
+def main():
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    payload = run_search()
+    OUT.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a sampled positive-mass Schwarzschild transition probe for the finite-capacity spacetime-deflection package.

Change:
- Adds a computable probe matching the local alpha/beta certificate to positive-mass Schwarzschild exterior.
- Searches over mass factors and transition radii.
- Generates artifacts/grf/schwarzschild_transition_probe.json.
- Records sampled WEC/DEC margin minima for the best candidate.
- Adds verifier and regression test.

Boundary:
- This is a numerical frontier probe.
- This is not interval arithmetic.
- A sampled pass is not a theorem.
- A sampled failure is not an impossibility theorem.
- The next missing object is an interval-certified positive-mass Schwarzschild transition ansatz.

Verification:
- python3 tools/grf_schwarzschild_transition_probe.py
- python3 scripts/verify_grf_schwarzschild_transition_probe.py
- python3 -m pytest -q tests/test_grf_schwarzschild_transition_probe.py