### PR TITLE
fix: support Python 3.9 TOML parsing in tests

### DIFF
--- a/tests/test_shadow_reuse_spec.py
+++ b/tests/test_shadow_reuse_spec.py
@@ -1,5 +1,8 @@
 import json
-import tomllib
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
Adds a tomllib/tomli compatibility fallback for Python 3.9 test environments.

Verified:
- tests/test_shadow_reuse_spec.py passed
- full pytest passed
- git diff --check passed

Known separate issue:
- tools/trust_verify.sh currently reaches lake build
- lakefile.toml declares default target URF
- URF.lean is absent in this documentation-surface repository

Boundary:
- test compatibility only
- does not alter release workflow semantics
- does not alter manuscript contents
- does not assert theorem-level closure