### PR TITLE
docs: present textbook as explanation layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+<!-- VERIFIED_FRONTIER_TRACKING_DOOR:BEGIN -->
+## Verified Frontier Tracking Explanation Layer
+
+This repository is the human-readable explanation layer for **Verified Frontier Tracking**.
+
+Its role is to translate the public URF/Chronos stack into readable form:
+
+| Question | Answer supplied here |
+|---|---|
+| What is the system? | A verification-first research framework for tracking hard claims without overclaiming |
+| Why does it matter? | It separates proved results from conditional bridges, interface objects, and open frontiers |
+| How should it be read? | Start with definitions, then status labels, then examples, then technical repositories |
+| What should not be inferred? | No theorem-level closure is claimed unless explicitly named and proved |
+
+Boundary: this repository explains the framework and its status discipline. It is not, by itself, a proof that every referenced frontier is solved.
+<!-- VERIFIED_FRONTIER_TRACKING_DOOR:END -->
+
 Unified Rigidity Framework Textbook
 Build
 make pdf


### PR DESCRIPTION
Adds the Verified Frontier Tracking public-door block for this repository.

Role:
- Make urf-textbook the explanation layer

Verified:
- README managed block added or updated
- git diff --check passed

Boundary:
- documentation/navigation/status-surface change only
- does not assert theorem-level closure
- does not alter proof objects, verifier semantics, or CI logic
