### PR TITLE
docs: present urf-textbook as Verified Frontier Tracking explanation layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
+<!-- VERIFIED_FRONTIER_TRACKING_EXPLANATION:BEGIN -->
+## Verified Frontier Tracking Explanation Layer
+
+This repository is the human-readable explanation layer for **Verified Frontier Tracking**.
+
+It explains the public URF/Chronos stack in ordinary research terms:
+
+| Question | Answer supplied here |
+|---|---|
+| What is the system? | A verification-first research framework for tracking hard claims without overclaiming |
+| Why does it matter? | It separates proved results from conditional bridges, interface objects, and open frontiers |
+| How should it be read? | Start with definitions, then status labels, then examples, then technical repositories |
+| What should not be inferred? | No theorem-level closure is claimed unless explicitly named and proved |
+
+Boundary: this repository explains the framework and its status discipline. It is not, by itself, a proof that every referenced frontier is solved.
+<!-- VERIFIED_FRONTIER_TRACKING_EXPLANATION:END -->
+
+
 <!-- VERIFIED_FRONTIER_TRACKING_DOOR:BEGIN -->
 ## Verified Frontier Tracking Explanation Layer
 


### PR DESCRIPTION
Makes urf-textbook the human-readable explanation layer for Verified Frontier Tracking.

Verified:
- git diff --check passed
- python3 -m pytest -q passed

Boundary:
- documentation/explanation-layer change only
- does not assert theorem-level closure
- does not promote conditional bridges, interface objects, or open frontiers
- does not alter verifier semantics, CI logic, or proof objects