### PR TITLE
docs: add GRF2026 audit no-promotion guard

### DIFF
--- a/artifacts/grf2026/audit_no_promotion_theorem_2026_05_15.json
+++ b/artifacts/grf2026/audit_no_promotion_theorem_2026_05_15.json
@@ -1,0 +1,42 @@
+{
+  "status": "VERIFIED_STATUS_GUARD_ONLY",
+  "date": "2026-05-15",
+  "scope": "GRF2026 conditional falsification audit",
+  "theorem": "GRF2026_Audit_NoPromotion",
+  "allowed_classifications": [
+    "CONDITIONALLY_REFUTABLE_PREMISE_LEVEL_ONLY",
+    "ATTACKABLE_NOT_REFUTED",
+    "ALIGNED_WITH_USER_FRAMEWORK",
+    "BLOCKED_PENDING_FULL_TEXT"
+  ],
+  "targets": {
+    "Apocalypse When?": "CONDITIONALLY_REFUTABLE_PREMISE_LEVEL_ONLY",
+    "The Gravitational Spectral Radio Forest": "ATTACKABLE_NOT_REFUTED",
+    "How Much Can Gravitons Be Squeezed?": "ATTACKABLE_NOT_REFUTED",
+    "Monogamous Entanglement Cheats at the Price of Complexity": "ALIGNED_WITH_USER_FRAMEWORK",
+    "Approaching the Surface of an Exotic Compact Object": "BLOCKED_PENDING_FULL_TEXT"
+  },
+  "proved_guard": {
+    "no_unconditional_disproof_promotion": true,
+    "no_theorem_level_refutation_promotion": true,
+    "no_solved_status_promotion": true,
+    "no_empirical_to_theorem_promotion": true
+  },
+  "nonclaims": [
+    "This is a repository status-guard theorem only.",
+    "No physical statement is proved.",
+    "No empirical falsification is proved.",
+    "No mathematical disproof of any GRF 2026 essay is proved.",
+    "No Chronos-RR closure is proved.",
+    "No H4.1/FGL closure is proved.",
+    "No P vs NP result is proved.",
+    "No Clay-problem closure is proved."
+  ],
+  "missing_objects_preserved": [
+    "No_Phantom_Admissibility_Proof",
+    "HII_3D_RadiativeTransfer_UpperBound",
+    "AxionBH_AllowedParameterSpace_Closure",
+    "SqueezedGraviton_SNR_Scan",
+    "ExoticCompactObject_FullText"
+  ]
+}

--- a/artifacts/grf2026/conditional_falsification_audit_2026_05_15.json
+++ b/artifacts/grf2026/conditional_falsification_audit_2026_05_15.json
@@ -1,0 +1,32 @@
+{
+  "status": "CONDITIONAL_FRAMEWORK_AUDIT_ONLY",
+  "date": "2026-05-15",
+  "scope": "Gravity Research Foundation 2026 winning essays",
+  "source_inputs": [
+    "uploaded Big Rip conditional audit",
+    "uploaded framework meta-audit",
+    "uploaded squeezed-graviton parameter-scan contract"
+  ],
+  "classifications": {
+    "Apocalypse When?": "CONDITIONALLY_REFUTABLE_PREMISE_LEVEL_ONLY",
+    "The Gravitational Spectral Radio Forest": "ATTACKABLE_NOT_REFUTED",
+    "How Much Can Gravitons Be Squeezed?": "ATTACKABLE_NOT_REFUTED",
+    "Monogamous Entanglement Cheats at the Price of Complexity": "ALIGNED_WITH_USER_FRAMEWORK",
+    "Approaching the Surface of an Exotic Compact Object": "BLOCKED_PENDING_FULL_TEXT"
+  },
+  "nonclaims": [
+    "No unconditional disproof of any GRF 2026 winning essay is claimed.",
+    "No empirical/model-dependent claim is promoted to theorem-level closure.",
+    "No_Phantom_Admissibility is an axiom-boundary, not a proved theorem.",
+    "HII_LineSurvival_Failure requires numerical radiative-transfer or observational upper-bound input.",
+    "No_Viable_SqueezedGraviton_Window requires external parameter-space closure plus SNR scan.",
+    "A finite grid scan does not imply universal theorem closure without interval-cover or analytic domination."
+  ],
+  "missing_objects": [
+    "No_Phantom_Admissibility_Proof",
+    "HII_3D_RadiativeTransfer_UpperBound",
+    "AxionBH_AllowedParameterSpace_Closure",
+    "SqueezedGraviton_SNR_Scan",
+    "ExoticCompactObject_FullText"
+  ]
+}

--- a/docs/status/GRF2026_AUDIT_NO_PROMOTION_THEOREM_2026_05_15.md
+++ b/docs/status/GRF2026_AUDIT_NO_PROMOTION_THEOREM_2026_05_15.md
@@ -1,0 +1,59 @@
+# GRF2026 Audit No-Promotion Theorem
+
+Status: VERIFIED_STATUS_GUARD_ONLY  
+Date: 2026-05-15  
+Scope: Gravity Research Foundation 2026 conditional falsification audit
+
+## Theorem
+
+For every GRF2026 target recorded in the audit table, the audit classification does not promote the target to unconditional disproof, theorem-level refutation, solved status, or physical falsification.
+
+## Formal Contract
+
+Let `GRF2026Target` be one of:
+
+- Apocalypse When?
+- The Gravitational Spectral Radio Forest
+- How Much Can Gravitons Be Squeezed?
+- Monogamous Entanglement Cheats at the Price of Complexity
+- Approaching the Surface of an Exotic Compact Object
+
+Let `AuditClass(GRF2026Target)` be its recorded audit classification.
+
+Then:
+
+```text
+∀ P : GRF2026Target,
+  AuditClass(P) ∈ {
+    CONDITIONALLY_REFUTABLE_PREMISE_LEVEL_ONLY,
+    ATTACKABLE_NOT_REFUTED,
+    ALIGNED_WITH_USER_FRAMEWORK,
+    BLOCKED_PENDING_FULL_TEXT
+  }
+  →
+  ¬PromotesToUnconditionalDisproof(P)
+  ∧ ¬PromotesToTheoremLevelRefutation(P)
+  ∧ ¬PromotesToSolvedStatus(P)
+  ∧ ¬PromotesEmpiricalConditionToTheorem(P)
+Classification Table
+Target	Classification
+Apocalypse When?	CONDITIONALLY_REFUTABLE_PREMISE_LEVEL_ONLY
+The Gravitational Spectral Radio Forest	ATTACKABLE_NOT_REFUTED
+How Much Can Gravitons Be Squeezed?	ATTACKABLE_NOT_REFUTED
+Monogamous Entanglement Cheats at the Price of Complexity	ALIGNED_WITH_USER_FRAMEWORK
+Approaching the Surface of an Exotic Compact Object	BLOCKED_PENDING_FULL_TEXT
+Boundary
+This is a repository status-guard theorem only.
+No physical statement is proved.
+No empirical falsification is proved.
+No mathematical disproof of any GRF 2026 essay is proved.
+No Chronos-RR closure is proved.
+No H4.1/FGL closure is proved.
+No P vs NP result is proved.
+No Clay-problem closure is proved.
+Missing Objects Preserved
+No_Phantom_Admissibility_Proof
+HII_3D_RadiativeTransfer_UpperBound
+AxionBH_AllowedParameterSpace_Closure
+SqueezedGraviton_SNR_Scan
+ExoticCompactObject_FullText

--- a/docs/status/GRF2026_AUDIT_NO_PROMOTION_THEOREM_2026_05_15.md
+++ b/docs/status/GRF2026_AUDIT_NO_PROMOTION_THEOREM_2026_05_15.md
@@ -8,52 +8,38 @@ Scope: Gravity Research Foundation 2026 conditional falsification audit
 
 For every GRF2026 target recorded in the audit table, the audit classification does not promote the target to unconditional disproof, theorem-level refutation, solved status, or physical falsification.
 
-## Formal Contract
+## Classification Table
 
-Let `GRF2026Target` be one of:
+| Target | Classification |
+|---|---|
+| Apocalypse When? | CONDITIONALLY_REFUTABLE_PREMISE_LEVEL_ONLY |
+| The Gravitational Spectral Radio Forest | ATTACKABLE_NOT_REFUTED |
+| How Much Can Gravitons Be Squeezed? | ATTACKABLE_NOT_REFUTED |
+| Monogamous Entanglement Cheats at the Price of Complexity | ALIGNED_WITH_USER_FRAMEWORK |
+| Approaching the Surface of an Exotic Compact Object | BLOCKED_PENDING_FULL_TEXT |
 
-- Apocalypse When?
-- The Gravitational Spectral Radio Forest
-- How Much Can Gravitons Be Squeezed?
-- Monogamous Entanglement Cheats at the Price of Complexity
-- Approaching the Surface of an Exotic Compact Object
+## Boundary
 
-Let `AuditClass(GRF2026Target)` be its recorded audit classification.
-
-Then:
-
-```text
-∀ P : GRF2026Target,
-  AuditClass(P) ∈ {
-    CONDITIONALLY_REFUTABLE_PREMISE_LEVEL_ONLY,
-    ATTACKABLE_NOT_REFUTED,
-    ALIGNED_WITH_USER_FRAMEWORK,
-    BLOCKED_PENDING_FULL_TEXT
-  }
-  →
-  ¬PromotesToUnconditionalDisproof(P)
-  ∧ ¬PromotesToTheoremLevelRefutation(P)
-  ∧ ¬PromotesToSolvedStatus(P)
-  ∧ ¬PromotesEmpiricalConditionToTheorem(P)
-Classification Table
-Target	Classification
-Apocalypse When?	CONDITIONALLY_REFUTABLE_PREMISE_LEVEL_ONLY
-The Gravitational Spectral Radio Forest	ATTACKABLE_NOT_REFUTED
-How Much Can Gravitons Be Squeezed?	ATTACKABLE_NOT_REFUTED
-Monogamous Entanglement Cheats at the Price of Complexity	ALIGNED_WITH_USER_FRAMEWORK
-Approaching the Surface of an Exotic Compact Object	BLOCKED_PENDING_FULL_TEXT
-Boundary
 This is a repository status-guard theorem only.
+
 No physical statement is proved.
+
 No empirical falsification is proved.
+
 No mathematical disproof of any GRF 2026 essay is proved.
+
 No Chronos-RR closure is proved.
+
 No H4.1/FGL closure is proved.
+
 No P vs NP result is proved.
+
 No Clay-problem closure is proved.
-Missing Objects Preserved
-No_Phantom_Admissibility_Proof
-HII_3D_RadiativeTransfer_UpperBound
-AxionBH_AllowedParameterSpace_Closure
-SqueezedGraviton_SNR_Scan
-ExoticCompactObject_FullText
+
+## Missing Objects Preserved
+
+- No_Phantom_Admissibility_Proof
+- HII_3D_RadiativeTransfer_UpperBound
+- AxionBH_AllowedParameterSpace_Closure
+- SqueezedGraviton_SNR_Scan
+- ExoticCompactObject_FullText

--- a/docs/status/GRF2026_CONDITIONAL_FALSIFICATION_AUDIT_2026_05_15.md
+++ b/docs/status/GRF2026_CONDITIONAL_FALSIFICATION_AUDIT_2026_05_15.md
@@ -1,0 +1,57 @@
+# GRF 2026 Conditional Falsification Audit
+
+Status: CONDITIONAL_FRAMEWORK_AUDIT_ONLY  
+Date: 2026-05-15  
+Scope: Gravity Research Foundation 2026 winning essays
+
+## Purpose
+
+This document archives a conditional audit of the 2026 Gravity Research Foundation winning essays against the user framework.
+
+It records classification only. It does not claim any winning essay has been overturned, falsified, or mathematically closed.
+
+## Source Inputs
+
+- Big Rip conditional audit.
+- Framework meta-audit.
+- Squeezed-graviton parameter-scan contract.
+
+## Classifications
+
+| Essay | Classification | Meaning |
+|---|---|---|
+| Apocalypse When? | CONDITIONALLY_REFUTABLE_PREMISE_LEVEL_ONLY | Blocked only if No_Phantom_Admissibility is proved or accepted as an admissibility axiom. |
+| The Gravitational Spectral Radio Forest | ATTACKABLE_NOT_REFUTED | Detectability can be attacked through HII radiative-transfer and line-survival modeling. |
+| How Much Can Gravitons Be Squeezed? | ATTACKABLE_NOT_REFUTED | Detectability can be attacked through allowed-parameter closure and SNR scanning. |
+| Monogamous Entanglement Cheats at the Price of Complexity | ALIGNED_WITH_USER_FRAMEWORK | The complexity/backreaction theme aligns with Chronos-style constraints. |
+| Approaching the Surface of an Exotic Compact Object | BLOCKED_PENDING_FULL_TEXT | No paper-specific audit is admissible until the full text is available. |
+
+## Boundary
+
+No unconditional rejection of any GRF 2026 winning essay is claimed.
+
+No empirical or model-dependent condition is promoted to theorem-level closure.
+
+No_Phantom_Admissibility is recorded as an axiom-boundary, not a proved theorem.
+
+HII_LineSurvival_Failure requires numerical radiative-transfer or observational upper-bound input.
+
+No_Viable_SqueezedGraviton_Window requires external parameter-space closure plus SNR scanning.
+
+A finite grid scan does not imply universal theorem closure without interval-cover or analytic domination.
+
+## Missing Objects
+
+- No_Phantom_Admissibility_Proof
+- HII_3D_RadiativeTransfer_UpperBound
+- AxionBH_AllowedParameterSpace_Closure
+- SqueezedGraviton_SNR_Scan
+- ExoticCompactObject_FullText
+
+## Final Status
+
+This archive is a claim-control and research-triage artifact only.
+
+It is suitable for urf-textbook.
+
+It is not a Chronos-RR theorem surface, not a URF-core theorem, and not a Lean closure artifact.

--- a/tests/test_grf2026_audit_no_promotion_theorem.py
+++ b/tests/test_grf2026_audit_no_promotion_theorem.py
@@ -1,0 +1,9 @@
+import subprocess
+import sys
+
+
+def test_grf2026_audit_no_promotion_theorem_verifier():
+    subprocess.run(
+        [sys.executable, "tools/verify_grf2026_audit_no_promotion_theorem.py"],
+        check=True,
+    )

--- a/tests/test_grf2026_conditional_falsification_audit.py
+++ b/tests/test_grf2026_conditional_falsification_audit.py
@@ -1,0 +1,8 @@
+import subprocess
+import sys
+
+def test_grf2026_conditional_falsification_audit_verifier():
+    subprocess.run(
+        [sys.executable, "tools/verify_grf2026_conditional_falsification_audit.py"],
+        check=True,
+    )

--- a/tools/verify_grf2026_audit_no_promotion_theorem.py
+++ b/tools/verify_grf2026_audit_no_promotion_theorem.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+import json
+
+doc = Path("docs/status/GRF2026_AUDIT_NO_PROMOTION_THEOREM_2026_05_15.md")
+artifact = Path("artifacts/grf2026/audit_no_promotion_theorem_2026_05_15.json")
+
+assert doc.exists(), doc
+assert artifact.exists(), artifact
+
+text = doc.read_text()
+data = json.loads(artifact.read_text())
+
+assert data["status"] == "VERIFIED_STATUS_GUARD_ONLY"
+assert data["theorem"] == "GRF2026_Audit_NoPromotion"
+
+allowed = {
+    "CONDITIONALLY_REFUTABLE_PREMISE_LEVEL_ONLY",
+    "ATTACKABLE_NOT_REFUTED",
+    "ALIGNED_WITH_USER_FRAMEWORK",
+    "BLOCKED_PENDING_FULL_TEXT",
+}
+
+assert set(data["allowed_classifications"]) == allowed
+assert set(data["targets"].values()).issubset(allowed)
+
+required_targets = {
+    "Apocalypse When?": "CONDITIONALLY_REFUTABLE_PREMISE_LEVEL_ONLY",
+    "The Gravitational Spectral Radio Forest": "ATTACKABLE_NOT_REFUTED",
+    "How Much Can Gravitons Be Squeezed?": "ATTACKABLE_NOT_REFUTED",
+    "Monogamous Entanglement Cheats at the Price of Complexity": "ALIGNED_WITH_USER_FRAMEWORK",
+    "Approaching the Surface of an Exotic Compact Object": "BLOCKED_PENDING_FULL_TEXT",
+}
+
+assert data["targets"] == required_targets
+
+for key in [
+    "no_unconditional_disproof_promotion",
+    "no_theorem_level_refutation_promotion",
+    "no_solved_status_promotion",
+    "no_empirical_to_theorem_promotion",
+]:
+    assert data["proved_guard"][key] is True, key
+
+required_nonclaims = [
+    "This is a repository status-guard theorem only.",
+    "No physical statement is proved.",
+    "No empirical falsification is proved.",
+    "No mathematical disproof of any GRF 2026 essay is proved.",
+    "No Chronos-RR closure is proved.",
+    "No H4.1/FGL closure is proved.",
+    "No P vs NP result is proved.",
+    "No Clay-problem closure is proved.",
+]
+
+for phrase in required_nonclaims:
+    assert phrase in data["nonclaims"], phrase
+    assert phrase in text, phrase
+
+for missing in [
+    "No_Phantom_Admissibility_Proof",
+    "HII_3D_RadiativeTransfer_UpperBound",
+    "AxionBH_AllowedParameterSpace_Closure",
+    "SqueezedGraviton_SNR_Scan",
+    "ExoticCompactObject_FullText",
+]:
+    assert missing in data["missing_objects_preserved"], missing
+    assert missing in text, missing
+
+for forbidden in [
+    "unconditionally disproves",
+    "unconditional disproof of",
+    "theorem-level refutation of",
+    "GRF winners refuted",
+    "paper is false",
+    "falsifies all",
+    "proves the essays wrong",
+    "solves GRF",
+]:
+    assert forbidden.lower() not in text.lower(), forbidden
+    assert forbidden.lower() not in json.dumps(data).lower(), forbidden
+
+print("GRF2026 audit no-promotion theorem verified.")

--- a/tools/verify_grf2026_conditional_falsification_audit.py
+++ b/tools/verify_grf2026_conditional_falsification_audit.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import json
+
+doc = Path("docs/status/GRF2026_CONDITIONAL_FALSIFICATION_AUDIT_2026_05_15.md")
+artifact = Path("artifacts/grf2026/conditional_falsification_audit_2026_05_15.json")
+
+assert doc.exists(), doc
+assert artifact.exists(), artifact
+
+data = json.loads(artifact.read_text())
+
+assert data["status"] == "CONDITIONAL_FRAMEWORK_AUDIT_ONLY"
+assert data["classifications"]["Apocalypse When?"] == "CONDITIONALLY_REFUTABLE_PREMISE_LEVEL_ONLY"
+assert data["classifications"]["The Gravitational Spectral Radio Forest"] == "ATTACKABLE_NOT_REFUTED"
+assert data["classifications"]["How Much Can Gravitons Be Squeezed?"] == "ATTACKABLE_NOT_REFUTED"
+assert data["classifications"]["Monogamous Entanglement Cheats at the Price of Complexity"] == "ALIGNED_WITH_USER_FRAMEWORK"
+assert data["classifications"]["Approaching the Surface of an Exotic Compact Object"] == "BLOCKED_PENDING_FULL_TEXT"
+
+required_nonclaims = [
+    "No unconditional disproof of any GRF 2026 winning essay is claimed.",
+    "No empirical/model-dependent claim is promoted to theorem-level closure.",
+    "No_Phantom_Admissibility is an axiom-boundary, not a proved theorem.",
+    "HII_LineSurvival_Failure requires numerical radiative-transfer or observational upper-bound input.",
+    "No_Viable_SqueezedGraviton_Window requires external parameter-space closure plus SNR scan.",
+    "A finite grid scan does not imply universal theorem closure without interval-cover or analytic domination."
+]
+
+for phrase in required_nonclaims:
+    assert phrase in data["nonclaims"], phrase
+
+for missing in [
+    "No_Phantom_Admissibility_Proof",
+    "HII_3D_RadiativeTransfer_UpperBound",
+    "AxionBH_AllowedParameterSpace_Closure",
+    "SqueezedGraviton_SNR_Scan",
+    "ExoticCompactObject_FullText"
+]:
+    assert missing in data["missing_objects"], missing
+
+text = doc.read_text()
+for forbidden in [
+    "disproves all",
+    "unconditionally disproves",
+    "GRF winners refuted",
+    "paper is false",
+    "theorem-level disproof"
+]:
+    assert forbidden.lower() not in text.lower(), forbidden
+
+print("GRF2026 conditional falsification audit verified.")


### PR DESCRIPTION
## Summary

Adds a GRF2026 audit no-promotion guard for the conditional falsification audit.

This records the five Gravity Research Foundation 2026 essay classifications while preventing promotion to unconditional disproof, theorem-level refutation, solved status, or empirical-to-theorem closure.

## Verified

- `python3 tools/verify_grf2026_audit_no_promotion_theorem.py`
- `python3 -m pytest -q tests/test_grf2026_audit_no_promotion_theorem.py`
- `python3 -m pytest -q`
- `git diff --check`

## Boundary

Repository status-guard only.

No physical statement is proved.

No empirical falsification is proved.

No mathematical disproof of any GRF 2026 essay is proved.

No Chronos-RR closure.

No H4.1/FGL closure.

No P vs NP result.

No Clay-problem closure.
