### PR TITLE
docs: add Dreams Math exposition frontier

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,7 @@
 # URF Textbook Roadmap
 
 ## Near-term (v1.1)
+- Add Dreams Math as a conditional exposition/frontier-isolation layer.
 - Add "How to read this textbook" section (conventions, dependency graph).
 - Add notation table and glossary.
 - Add theorem/definition indexing policy (labels + crossrefs).

--- a/docs/dreams/DREAMS_MATH.md
+++ b/docs/dreams/DREAMS_MATH.md
@@ -1,0 +1,161 @@
+# Dreams Math
+
+Status: CONDITIONAL_EXPOSITION_FRONTIER
+
+## Purpose
+
+Dreams Math is the exposition name for speculative-but-structured URF routes that are useful for generating theorem targets, frontier statements, and reduction diagrams before they become formal source-theorem artifacts.
+
+It is not a theorem layer.
+
+## Reading Rule
+
+A Dreams Math object is admissible in this textbook only when it is recorded as one of:
+
+- heuristic route
+- conditional bridge
+- frontier target
+- obstruction map
+- source-of-truth pointer
+- executable verifier target
+
+It is not admissible as:
+
+- unconditional proof
+- theorem-level closure
+- Clay-problem solution
+- P vs NP solution
+- Chronos-RR closure
+- H4.1/FGL closure
+- UniversalFiberEntropyGap theorem
+
+## Current Dreams Math Core
+
+### D1. Latent Trace Entropy Route
+
+Formal role:
+
+A latent trace entropy route tries to convert rank-rate structure into fiber-entropy mass through a trace-like entropy functional.
+
+Required missing objects:
+
+1. RankRateBridgeLaw
+2. RateThickFiberCoercivity
+3. admissible nonzero fiber witness
+4. uniform lower entropy floor
+
+Boundary:
+
+The route is conditional until all required missing objects are proved in a buildable formal source repository.
+
+### D2. Path Entropy Large-Deviation Route
+
+Formal role:
+
+A path entropy route studies entropy values along admissible state paths and asks whether concentration or large-deviation estimates yield a uniform fiber-entropy lower bound.
+
+Required missing objects:
+
+1. admissible path measure
+2. entropy pushforward measure
+3. uniform support floor
+4. rate function lower control
+5. finite-to-uniform transfer principle
+
+Boundary:
+
+Pointwise positivity is insufficient. UniversalFiberEntropyGap requires a single uniform positive lower bound.
+
+### D3. Rate-Thick Fiber Coercivity Route
+
+Formal role:
+
+A rate-thick route restricts attention to domains where the rank-rate signal is quantitatively nondegenerate and asks whether fiber mass admits a uniform lower entropy floor.
+
+Required missing objects:
+
+1. rate-thick admissible domain
+2. nonnull fiber witness
+3. entropy minimum domination
+4. uniform lower envelope
+
+Boundary:
+
+Finite registered or model-specific closures do not imply unrestricted RateThickFiberCoercivity.
+
+### D4. Lyapunov Fiber-Bound Route
+
+Formal role:
+
+A Lyapunov route attempts to certify entropy floor control through a monotone or coercive Lyapunov datum.
+
+Required missing objects:
+
+1. admissible replacement domain
+2. nonzero bound system
+3. LyapunovFiberBoundData
+4. uniform fiber-floor extraction
+
+Boundary:
+
+The unrestricted certificate is obstructed unless the current interface excludes zero-bound systems or replaces the domain.
+
+### D5. Gravity / Boundary Compactness Dream Route
+
+Formal role:
+
+A gravity dream route attempts to move from finite detector algebra, finite energy/flux, and admissible backreaction controls toward boundary compactness and collapse gates.
+
+Required missing objects:
+
+1. Einstein dynamics interface
+2. finite-energy matter admissibility
+3. nonlinear backreaction control
+4. covariant entropy bound
+5. non-symmetric trapped-surface criterion
+6. collapse-to-censorship bridge
+
+Boundary:
+
+This does not prove Cosmic Censorship, the Hoop Conjecture, unrestricted UniversalBoundaryCompactness, or unrestricted QL_CollapseGate.
+
+## Source-of-Truth Rule
+
+Every theorem-level claim generated from Dreams Math must inherit from a buildable formal source repository and must specify:
+
+- repository
+- commit or release
+- file path
+- theorem or artifact name
+- status label
+- boundary statement
+
+## Forbidden Promotion Rule
+
+The following inference is invalid:
+
+Dreams Math route + verifier + dashboard row + exposition
+= theorem-level proof
+
+The only admissible upgrade path is:
+
+Dreams Math route
+→ formal frontier target
+→ buildable theorem statement
+→ proof without central axioms/admits/sorry
+→ external status update
+→ dashboard/textbook synchronization
+
+## Boundary
+
+Dreams Math is a structured idea-generation and frontier-isolation layer.
+
+It does not prove:
+
+- unrestricted UniversalFiberEntropyGap
+- unrestricted Chronos-RR
+- unrestricted H4.1/FGL
+- P vs NP
+- Cosmic Censorship
+- the Hoop Conjecture
+- any Clay problem

--- a/docs/index/DOCUMENTATION_INDEX.md
+++ b/docs/index/DOCUMENTATION_INDEX.md
@@ -17,6 +17,7 @@ Unified Rigidity Framework ecosystem.
 - docs/diagrams/urf_dependency_map.md  
 
 ## Mathematical Content
+- docs/dreams/DREAMS_MATH.md
 
 - docs/invariants/URF_INVARIANTS.md  
 - docs/open_problems/OPEN_PROBLEMS.md  

--- a/tests/test_dreams_math.py
+++ b/tests/test_dreams_math.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+def test_dreams_math_status_and_boundary():
+    doc = Path("docs/dreams/DREAMS_MATH.md").read_text()
+    assert "Status: CONDITIONAL_EXPOSITION_FRONTIER" in doc
+    assert "It is not a theorem layer." in doc
+    assert "Dreams Math is a structured idea-generation and frontier-isolation layer." in doc
+    assert "unrestricted UniversalFiberEntropyGap" in doc
+    assert "unrestricted Chronos-RR" in doc
+    assert "unrestricted H4.1/FGL" in doc
+    assert "P vs NP" in doc
+    assert "any Clay problem" in doc
+
+def test_dreams_math_is_indexed():
+    idx = Path("docs/index/DOCUMENTATION_INDEX.md").read_text()
+    roadmap = Path("ROADMAP.md").read_text()
+    assert "docs/dreams/DREAMS_MATH.md" in idx
+    assert "Dreams Math" in roadmap

--- a/tools/verify_dreams_math.py
+++ b/tools/verify_dreams_math.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+DOC = Path("docs/dreams/DREAMS_MATH.md")
+INDEX = Path("docs/index/DOCUMENTATION_INDEX.md")
+ROADMAP = Path("ROADMAP.md")
+
+required = [
+    "Status: CONDITIONAL_EXPOSITION_FRONTIER",
+    "It is not a theorem layer.",
+    "Pointwise positivity is insufficient.",
+    "UniversalFiberEntropyGap requires a single uniform positive lower bound.",
+    "does not prove Cosmic Censorship",
+    "does not prove:",
+    "unrestricted UniversalFiberEntropyGap",
+    "unrestricted Chronos-RR",
+    "unrestricted H4.1/FGL",
+    "P vs NP",
+    "any Clay problem",
+]
+
+for path in [DOC, INDEX, ROADMAP]:
+    assert path.exists(), f"missing {path}"
+
+doc = DOC.read_text()
+for token in required:
+    assert token in doc, f"missing token: {token}"
+
+assert "docs/dreams/DREAMS_MATH.md" in INDEX.read_text()
+assert "Dreams Math" in ROADMAP.read_text()
+
+forbidden = [
+    "proves P vs NP",
+    "solves P vs NP",
+    "proves Cosmic Censorship",
+    "proves the Hoop Conjecture",
+    "proves unrestricted UniversalFiberEntropyGap",
+    "proves unrestricted Chronos-RR",
+    "proves unrestricted H4.1/FGL",
+    "solves any Clay problem",
+    "unconditional final proof",
+]
+
+lower = doc.lower()
+for phrase in forbidden:
+    assert phrase.lower() not in lower, f"forbidden promotion phrase: {phrase}"
+
+print("Dreams Math exposition frontier verified.")


### PR DESCRIPTION
## Summary

Adds Dreams Math as a conditional exposition/frontier-isolation chapter in the URF textbook.

## Verified

- `python3 tools/verify_dreams_math.py`
- `python3 -m pytest -q tests/test_dreams_math.py`
- `git diff --check`

## Boundary

Dreams Math is an exposition/frontier-isolation layer only.

Does not prove:

- unrestricted UniversalFiberEntropyGap
- unrestricted Chronos-RR
- unrestricted H4.1/FGL
- P vs NP
- Cosmic Censorship
- the Hoop Conjecture
- any Clay problem