### PR TITLE
docs: add temporal relaxation wave intuition box

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,7 @@ Theorem-status rule:
 
 Source-of-truth document:
 - `docs/status/SOURCE_OF_TRUTH_2026_04_27.md`
+
+## Temporal Relaxation Wave
+
+- [Temporal Relaxation Wave Intuition Box](docs/notes/TEMPORAL_RELAXATION_WAVE_INTUITION_BOX_2026_05_18.md)

--- a/docs/notes/TEMPORAL_RELAXATION_WAVE_INTUITION_BOX_2026_05_18.md
+++ b/docs/notes/TEMPORAL_RELAXATION_WAVE_INTUITION_BOX_2026_05_18.md
@@ -1,0 +1,121 @@
+# Temporal Relaxation Wave Intuition Box
+
+Status: `TEXTBOOK_INTUITION_BOX_ONLY`
+
+## Object
+
+A `TemporalRelaxationWave` is the scalar field
+
+\[
+W(t)=A e^{-\lambda t}\sin(\omega t+\phi),
+\]
+
+where
+
+\[
+A\ge 0,\qquad \lambda>0,\qquad \omega\in\mathbb R,\qquad \phi\in\mathbb R,\qquad t\ge 0.
+\]
+
+Interpretation:
+
+\[
+\text{disturbance}
+\longrightarrow
+\text{phase mismatch}
+\longrightarrow
+\text{relaxation ripple}
+\longrightarrow
+\text{decay back toward alignment}.
+\]
+
+## Envelope Energy
+
+Define the instantaneous energy and envelope energy by
+
+\[
+E_{\mathrm{inst}}(t)=|W(t)|^2
+\]
+
+and
+
+\[
+E_{\mathrm{env}}(t)=A^2e^{-2\lambda t}.
+\]
+
+Since
+
+\[
+|\sin(\omega t+\phi)|\le 1,
+\]
+
+we have
+
+\[
+E_{\mathrm{inst}}(t)
+=
+A^2e^{-2\lambda t}\sin^2(\omega t+\phi)
+\le
+A^2e^{-2\lambda t}
+=
+E_{\mathrm{env}}(t).
+\]
+
+Also,
+
+\[
+E_{\mathrm{env}}(t)=E_{\mathrm{env}}(0)e^{-2\lambda t}.
+\]
+
+Therefore the rigorous decay statement is
+
+\[
+\boxed{
+E_{\mathrm{inst}}(t)\le E_{\mathrm{env}}(0)e^{-2\lambda t}.
+}
+\]
+
+The estimate
+
+\[
+E_{\mathrm{inst}}(t)\le E_{\mathrm{inst}}(0)e^{-2\lambda t}
+\]
+
+is not generally valid without an additional phase assumption, because \(E_{\mathrm{inst}}(0)\) may vanish while later oscillations are nonzero.
+
+## Disturbance Recovery Example
+
+Let a system receive a disturbance of size \(D\ge 0\) at time \(t=0\). A first-order relaxation-ripple model is
+
+\[
+R(t)=D e^{-\lambda t}\sin(\omega t),
+\qquad t\ge 0.
+\]
+
+Then
+
+\[
+|R(t)|\le D e^{-\lambda t},
+\]
+
+and
+
+\[
+|R(t)|^2\le D^2e^{-2\lambda t}.
+\]
+
+Thus the visible ripple may oscillate, but its recovery envelope decays exponentially.
+
+## Boundary
+
+This is a textbook intuition box only.
+
+It does not prove:
+
+- any URF theorem
+- any Chronos-RR theorem
+- any H4.1/FGL theorem
+- `UniversalFiberEntropyGap`
+- P vs NP
+- any Clay problem
+
+It may be connected to URF only if later upgraded into a genuine Lyapunov estimate, entropy-dissipation inequality, or coercive decay bound.

--- a/tests/test_temporal_relaxation_wave_intuition_box.py
+++ b/tests/test_temporal_relaxation_wave_intuition_box.py
@@ -1,0 +1,31 @@
+import math
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs/notes/TEMPORAL_RELAXATION_WAVE_INTUITION_BOX_2026_05_18.md"
+
+def test_temporal_relaxation_wave_doc_boundary_tokens():
+    text = DOC.read_text()
+    assert "TEXTBOOK_INTUITION_BOX_ONLY" in text
+    assert "This is a textbook intuition box only." in text
+    assert "It may be connected to URF only if later upgraded" in text
+    assert "P vs NP" in text
+    assert "any Clay problem" in text
+
+def test_temporal_relaxation_wave_envelope_bound_numeric():
+    A = 3.0
+    lam = 0.7
+    omega = 2.3
+    phi = 0.4
+
+    for i in range(100):
+        t = i / 10
+        W = A * math.exp(-lam * t) * math.sin(omega * t + phi)
+        e_inst = W * W
+        e_env = A * A * math.exp(-2 * lam * t)
+        assert e_inst <= e_env + 1e-12
+
+def test_instantaneous_initial_energy_warning_present():
+    text = DOC.read_text()
+    assert "not generally valid without an additional phase assumption" in text
+    assert "may vanish while later oscillations are nonzero" in text

--- a/tools/verify_temporal_relaxation_wave_intuition_box.py
+++ b/tools/verify_temporal_relaxation_wave_intuition_box.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs/notes/TEMPORAL_RELAXATION_WAVE_INTUITION_BOX_2026_05_18.md"
+README = ROOT / "README.md"
+
+required = [
+    "Status: `TEXTBOOK_INTUITION_BOX_ONLY`",
+    "TemporalRelaxationWave",
+    "W(t)=A e^{-\\lambda t}\\sin(\\omega t+\\phi)",
+    "E_{\\mathrm{inst}}(t)",
+    "E_{\\mathrm{env}}(t)",
+    "E_{\\mathrm{inst}}(t)\\le E_{\\mathrm{env}}(0)e^{-2\\lambda t}",
+    "Disturbance Recovery Example",
+    "This is a textbook intuition box only.",
+    "It may be connected to URF only if later upgraded",
+]
+
+forbidden = [
+    "proves URF",
+    "proves Chronos-RR",
+    "proves H4.1/FGL",
+    "UniversalFiberEntropyGap is proved",
+    "P vs NP is solved",
+    "Clay problem is solved",
+    "theorem-level closure",
+]
+
+def main() -> None:
+    text = DOC.read_text()
+
+    for token in required:
+        assert token in text, f"missing required token: {token}"
+
+    for token in forbidden:
+        assert token not in text, f"forbidden overclaim token present: {token}"
+
+    if README.exists():
+        readme = README.read_text()
+        assert "TEMPORAL_RELAXATION_WAVE_INTUITION_BOX_2026_05_18.md" in readme
+
+    print("Temporal relaxation wave intuition box verified.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary
Adds a textbook-only TemporalRelaxationWave intuition box.

Defines:
- `TemporalRelaxationWave`
- instantaneous energy
- envelope energy
- exponential envelope decay estimate
- disturbance recovery example

Verified
- `python3 tools/verify_temporal_relaxation_wave_intuition_box.py`
- `python3 -m pytest -q tests/test_temporal_relaxation_wave_intuition_box.py`
- `python3 -m pytest -q`
- `git diff --check`

Boundary
Textbook intuition box only.

Does not prove:
- any URF theorem
- any Chronos-RR theorem
- any H4.1/FGL theorem
- `UniversalFiberEntropyGap`
- P vs NP
- any Clay problem

URF connection is deferred until a genuine Lyapunov estimate, entropy-dissipation inequality, or coercive decay bound is introduced.
