### PR TITLE
docs: add universal translation spine explanation

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -109,4 +109,5 @@
 \include{tex/appendices/E_symbol_index}
 \include{tex/appendices/F_framework_summary}
 
+\input{tex/chapters/universal_translation_spine_v1}
 \end{document}

--- a/tex/chapters/universal_translation_spine_v1.tex
+++ b/tex/chapters/universal_translation_spine_v1.tex
@@ -1,0 +1,38 @@
+\section{How URF Unifies Domains}
+\label{sec:universal-translation-spine-v1}
+
+The Universal Translation Spine is the registry-level form of the URF unification claim. It does not assert that every domain theorem has been solved. It records the common structural shape used to compare domain surfaces.
+
+\[
+\mathrm{domain}
+\longrightarrow
+\mathrm{encoder}
+\longrightarrow
+\mathrm{rigidity\ grammar\ fragment}
+\longrightarrow
+\mathrm{invariant}
+\longrightarrow
+\mathrm{frontier\ status}.
+\]
+
+A domain is any mathematical, computational, physical, or information-theoretic setting under study. An encoder records how that domain is translated into URF data. A rigidity grammar fragment records the shared structural language. An invariant records what is preserved, obstructed, bounded, or forced. A frontier status records what is closed, conditional, restricted, or still open.
+
+This spine makes the unification thesis auditable: different subjects are not treated as identical, but they are compared through the same tuple type.
+
+\begin{center}
+\begin{tabular}{p{0.22\linewidth}p{0.25\linewidth}p{0.25\linewidth}p{0.18\linewidth}}
+\toprule
+Domain & Encoder & Invariant & Frontier status \\
+\midrule
+Computation & local process data & width obstruction & open or conditional \\
+Physics & operational constraint data & boundary rigidity & open or conditional \\
+Gravity & collapse boundary data & compactness obstruction & open or conditional \\
+Entropy fibers & fiber mass data & entropy balance & open or conditional \\
+Temporal relaxation & dissipation data & decay obstruction & open or conditional \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+The spine is therefore a structural unification surface. It is useful because it gives every domain the same audit fields, while preserving the boundary between registry consistency and theorem closure.
+
+It does not prove unrestricted Chronos-RR, unrestricted H4.1/FGL, P vs NP, or any Clay problem.


### PR DESCRIPTION
Summary
Adds a textbook section explaining how URF unifies domains through the Universal Translation Spine.

Verified
- TeX page added and included in the root document
- `git diff --check`
- Local LaTeX build when available

Boundary
Expository textbook page only.

Does not prove:
- unrestricted Chronos-RR
- unrestricted H4.1/FGL
- P vs NP
- any Clay problem
