### PR TITLE
docs: add stable trace no-go theorem note

### DIFF
--- a/artifacts/textbook/stable_trace_no_go_note_2026_05_19.json
+++ b/artifacts/textbook/stable_trace_no_go_note_2026_05_19.json
@@ -1,0 +1,33 @@
+{
+"name": "stable_trace_no_go_note",
+"date": "2026-05-19",
+"status": "EXTERNAL_READABLE_NOTE / REFUTED_UNCONDITIONAL_TARGET",
+"source_repo": "urf-core",
+"source_pr": 341,
+"source_commit": "f1f28fa",
+"result": "Unconditional stable trace targets are refuted for arbitrary CapacityInterface.",
+"surviving_statement": "[Inhabited X.Trace] -> StableGenAdmissibleTrace X iff StableTraceCertificateExists X",
+"countermodels": [
+{
+"Generator": "Unit",
+"Trace": "Empty",
+"StableGen": "fun _ => False",
+"refutes": "StableGenAdmissibleTrace -> StableTraceCertificateExists"
+},
+{
+"Generator": "Unit",
+"Trace": "Empty",
+"StableGen": "fun _ => True",
+"refutes": "forall X, StableGenAdmissibleTrace X"
+}
+],
+"does_not_prove": [
+"unconditional StableTraceCertificateExists",
+"unconditional StableGenAdmissibleTrace",
+"unrestricted UniversalFiberEntropyGap",
+"unrestricted Chronos-RR",
+"unrestricted H4.1/FGL",
+"P vs NP",
+"any Clay problem"
+]
+}

--- a/docs/theorems/STABLE_TRACE_NO_GO.md
+++ b/docs/theorems/STABLE_TRACE_NO_GO.md
@@ -1,0 +1,55 @@
+# Stable Trace No-Go Theorem
+
+Status: `EXTERNAL_READABLE_NOTE / REFUTED_UNCONDITIONAL_TARGET`
+
+## Theorem
+
+For an arbitrary URF capacity interface, the following unconditional targets are false:
+
+```text
+∀ X, StableTraceCertificateExists X
+∀ X, StableGenAdmissibleTrace X
+∀ X, StableGenAdmissibleTrace X → StableTraceCertificateExists X
+Exact surviving statement
+The valid equivalence requires inhabited traces:
+[Inhabited X.Trace] →
+StableGenAdmissibleTrace X ↔ StableTraceCertificateExists X
+Countermodel 1: no certificate from vacuous stability
+Let:
+Generator := Unit
+Trace := Empty
+StableGen := fun _ => False
+Then StableGenAdmissibleTrace holds vacuously, but StableTraceCertificateExists fails because there is no total function:
+Unit → Empty
+Thus:
+StableGenAdmissibleTrace X → StableTraceCertificateExists X
+is not valid for arbitrary CapacityInterface.
+Countermodel 2: no stable admissible trace
+Let:
+Generator := Unit
+Trace := Empty
+StableGen := fun _ => True
+Then StableGenAdmissibleTrace fails because the unique generator is stable but no trace exists.
+Thus:
+∀ X, StableGenAdmissibleTrace X
+is not valid for arbitrary CapacityInterface.
+Interpretation
+The no-go result is credibility-positive because the framework rejects an overstrong target rather than forcing a false closure.
+The correct dependency is:
+[Inhabited X.Trace]
+Without this dependency, a total certificate function cannot be constructed.
+Formal source
+This note summarizes the urf-core Lean result:
+lean/URF/Foundation/UnconditionalStableTraceNoGo.lean
+Merged result:
+urf-core PR #341
+main commit f1f28fa
+Boundary
+This note does not prove:
+- unconditional `StableTraceCertificateExists`
+- unconditional `StableGenAdmissibleTrace`
+- unrestricted `UniversalFiberEntropyGap`
+- unrestricted Chronos-RR
+- unrestricted H4.1/FGL
+- P vs NP
+- any Clay problem

--- a/tests/test_stable_trace_no_go_note.py
+++ b/tests/test_stable_trace_no_go_note.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import json
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_stable_trace_no_go_note_doc():
+    text = (ROOT / "docs/theorems/STABLE_TRACE_NO_GO.md").read_text()
+    assert "Status: `EXTERNAL_READABLE_NOTE / REFUTED_UNCONDITIONAL_TARGET`" in text
+    assert "[Inhabited X.Trace]" in text
+    assert "Generator := Unit" in text
+    assert "Trace := Empty" in text
+    assert "urf-core PR #341" in text
+    assert "main commit f1f28fa" in text
+
+
+def test_stable_trace_no_go_note_boundary():
+    text = (ROOT / "docs/theorems/STABLE_TRACE_NO_GO.md").read_text()
+    assert "This note does not prove:" in text
+    assert "- unconditional `StableTraceCertificateExists`" in text
+    assert "- unconditional `StableGenAdmissibleTrace`" in text
+    assert "- unrestricted `UniversalFiberEntropyGap`" in text
+    assert "- unrestricted Chronos-RR" in text
+    assert "- unrestricted H4.1/FGL" in text
+    assert "- P vs NP" in text
+    assert "- any Clay problem" in text
+
+
+def test_stable_trace_no_go_note_artifact():
+    data = json.loads((ROOT / "artifacts/textbook/stable_trace_no_go_note_2026_05_19.json").read_text())
+    assert data["status"] == "EXTERNAL_READABLE_NOTE / REFUTED_UNCONDITIONAL_TARGET"
+    assert data["source_repo"] == "urf-core"
+    assert data["source_pr"] == 341
+    assert data["source_commit"] == "f1f28fa"
+    assert len(data["countermodels"]) == 2

--- a/tools/verify_stable_trace_no_go_note.py
+++ b/tools/verify_stable_trace_no_go_note.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+import json
+
+ROOT = Path(__file__).resolve().parents[1]
+
+doc = ROOT / "docs/theorems/STABLE_TRACE_NO_GO.md"
+artifact = ROOT / "artifacts/textbook/stable_trace_no_go_note_2026_05_19.json"
+
+doc_text = doc.read_text()
+data = json.loads(artifact.read_text())
+
+required_doc = [
+    "Status: `EXTERNAL_READABLE_NOTE / REFUTED_UNCONDITIONAL_TARGET`",
+    "For an arbitrary URF capacity interface",
+    "The valid equivalence requires inhabited traces",
+    "[Inhabited X.Trace]",
+    "Generator := Unit",
+    "Trace := Empty",
+    "StableGen := fun _ => False",
+    "StableGen := fun _ => True",
+    "Unit → Empty",
+    "urf-core PR #341",
+    "main commit f1f28fa",
+    "This note does not prove:",
+    "unconditional `StableTraceCertificateExists`",
+    "unconditional `StableGenAdmissibleTrace`",
+    "unrestricted `UniversalFiberEntropyGap`",
+    "unrestricted Chronos-RR",
+    "unrestricted H4.1/FGL",
+    "P vs NP",
+    "any Clay problem",
+]
+
+for token in required_doc:
+    assert token in doc_text, token
+
+assert data["status"] == "EXTERNAL_READABLE_NOTE / REFUTED_UNCONDITIONAL_TARGET"
+assert data["source_repo"] == "urf-core"
+assert data["source_pr"] == 341
+assert data["source_commit"] == "f1f28fa"
+assert "Inhabited X.Trace" in data["surviving_statement"]
+assert len(data["countermodels"]) == 2
+
+for forbidden in [
+    "solves P vs NP",
+    "proves P vs NP",
+    "solves any Clay problem",
+    "proves any Clay problem",
+    "unrestricted Chronos-RR is proved",
+    "unrestricted UniversalFiberEntropyGap is proved",
+]:
+    assert forbidden not in doc_text
+
+print("Stable trace no-go note verified.")


### PR DESCRIPTION
Summary
Adds an external-readable theorem note for the stable trace no-go result.

Source:
- urf-core PR #341
- urf-core main commit f1f28fa

Records:
- unconditional StableTraceCertificateExists is refuted
- unconditional StableGenAdmissibleTrace is refuted
- exact surviving condition is `[Inhabited X.Trace]`
- two empty-trace countermodels explain the obstruction

Verified:
- `python3 tools/verify_stable_trace_no_go_note.py`
- `python3 -m pytest -q tests/test_stable_trace_no_go_note.py`
- `python3 -m pytest -q`
- `git diff --check`

Boundary:
External-readable note only.

Does not prove:
- unconditional StableTraceCertificateExists
- unconditional StableGenAdmissibleTrace
- unrestricted UniversalFiberEntropyGap
- unrestricted Chronos-RR
- unrestricted H4.1/FGL
- P vs NP
- any Clay problem
