### PR TITLE
docs(essay): add inner-boundary sign condition

### DIFF
--- a/artifacts/grf/inner_boundary_sign_condition.json
+++ b/artifacts/grf/inner_boundary_sign_condition.json
@@ -1,0 +1,15 @@
+{
+  "status": "ANALYTIC_FRONTIER_CONDITION",
+  "targeted_margin": "rho_minus_pt",
+  "targeted_cell": "inner boundary cell",
+  "condition": "For a transition shell using Misner-Sharp mass m(r) and radial NEC saturation, the inner-boundary margin is controlled by the sign and size of the tangential-pressure term. A certified transition ansatz must impose an explicit lower bound on rho_minus_pt at r1 before interval search.",
+  "required_next_constraint": "Choose inner data m(r1), m'(r1), m''(r1), Phi'(r1), Phi''(r1) so that rho_minus_pt(r1) >= 0 and the first interval cell has a nonnegative lower bound.",
+  "does_not_prove": [
+    "global matching theorem",
+    "positive interval certificate",
+    "WEC/DEC closure",
+    "GRF theorem-level closure",
+    "physical realization theorem"
+  ],
+  "next_missing_object": "inner-boundary rho_minus_pt nonnegative sign lemma"
+}

--- a/docs/essays/GRF_2026_INNER_BOUNDARY_SIGN_CONDITION.md
+++ b/docs/essays/GRF_2026_INNER_BOUNDARY_SIGN_CONDITION.md
@@ -1,0 +1,65 @@
+# GRF 2026 — Inner-Boundary Sign Condition
+
+## Status
+
+`ANALYTIC_FRONTIER_CONDITION`
+
+## Target
+
+The remaining interval obstruction is localized at the inner transition cell.
+
+Targeted margin:
+
+\[
+\rho-p_t.
+\]
+
+Targeted cell:
+
+\[
+r\in[r_1,r_1+\Delta r].
+\]
+
+## Analytic frontier condition
+
+For a transition shell using Misner-Sharp mass \(m(r)\) and radial NEC saturation, the next ansatz cannot be chosen only by global smoothing.
+
+It must impose inner-boundary tangential-pressure control:
+
+\[
+(\rho-p_t)(r_1)\ge 0.
+\]
+
+The first certified interval cell must also satisfy
+
+\[
+\inf_{r\in[r_1,r_1+\Delta r]}(\rho-p_t)(r)\ge0.
+\]
+
+## Required next constraint
+
+Choose inner data
+
+\[
+m(r_1),\quad m'(r_1),\quad m''(r_1),\quad \Phi'(r_1),\quad \Phi''(r_1)
+\]
+
+so that the analytic boundary inequality holds before interval search.
+
+## Boundary
+
+This is an analytic frontier condition.
+
+It is not a global matching theorem.
+
+It is not a positive interval certificate.
+
+It is not WEC/DEC closure.
+
+It is not GRF theorem-level closure.
+
+It is not a physical realization theorem.
+
+## Next missing object
+
+inner-boundary rho_minus_pt nonnegative sign lemma

--- a/scripts/verify_grf_inner_boundary_sign_condition.py
+++ b/scripts/verify_grf_inner_boundary_sign_condition.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+DOC = Path("docs/essays/GRF_2026_INNER_BOUNDARY_SIGN_CONDITION.md")
+ART = Path("artifacts/grf/inner_boundary_sign_condition.json")
+
+for path in (DOC, ART):
+    if not path.exists():
+        raise SystemExit(f"missing required file: {path}")
+
+doc = DOC.read_text(encoding="utf-8")
+for tok in [
+    "ANALYTIC_FRONTIER_CONDITION",
+    "rho-p_t",
+    "inner-boundary tangential-pressure control",
+    "(\\rho-p_t)(r_1)\\ge 0",
+    "\\inf_{r\\in[r_1,r_1+\\Delta r]}(\\rho-p_t)(r)\\ge0",
+    "This is an analytic frontier condition.",
+    "It is not a global matching theorem.",
+    "It is not a positive interval certificate.",
+    "It is not WEC/DEC closure.",
+    "It is not GRF theorem-level closure.",
+    "inner-boundary rho_minus_pt nonnegative sign lemma",
+]:
+    if tok not in doc:
+        raise SystemExit(f"missing doc token: {tok}")
+
+data = json.loads(ART.read_text(encoding="utf-8"))
+if data["status"] != "ANALYTIC_FRONTIER_CONDITION":
+    raise SystemExit("bad status")
+if data["targeted_margin"] != "rho_minus_pt":
+    raise SystemExit("bad targeted_margin")
+if data["next_missing_object"] != "inner-boundary rho_minus_pt nonnegative sign lemma":
+    raise SystemExit("bad next missing object")
+
+for forbidden in [
+    "global matching theorem proved",
+    "positive interval certificate proved",
+    "WEC/DEC closure proved",
+    "GRF theorem-level closure proved"
+]:
+    if forbidden in doc or forbidden in json.dumps(data):
+        raise SystemExit(f"forbidden overclaim: {forbidden}")
+
+print("GRF inner-boundary sign condition verification OK.")

--- a/tests/test_grf_inner_boundary_sign_condition.py
+++ b/tests/test_grf_inner_boundary_sign_condition.py
@@ -1,0 +1,14 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_inner_boundary_sign_condition_artifact():
+    data = json.loads(Path("artifacts/grf/inner_boundary_sign_condition.json").read_text())
+    assert data["status"] == "ANALYTIC_FRONTIER_CONDITION"
+    assert data["targeted_margin"] == "rho_minus_pt"
+    assert data["next_missing_object"] == "inner-boundary rho_minus_pt nonnegative sign lemma"
+
+
+def test_inner_boundary_sign_condition_verifier():
+    subprocess.run(["python3", "scripts/verify_grf_inner_boundary_sign_condition.py"], check=True)


### PR DESCRIPTION
Adds the analytic inner-boundary sign condition for the GRF transition-shell frontier.

Change:
- Isolates rho_minus_pt as the inner-cell obstruction.
- Records the required analytic condition rho_minus_pt(r1) >= 0.
- Requires a nonnegative interval lower bound on the first cell before global interval search.
- Adds a JSON artifact, verifier, and regression test.

Boundary:
- This is an analytic frontier condition.
- It is not a global matching theorem.
- It is not a positive interval certificate.
- It is not WEC/DEC closure.
- It is not GRF theorem-level closure.
- It is not a physical realization theorem.

Verification:
- python3 scripts/verify_grf_inner_boundary_sign_condition.py
- python3 -m pytest -q tests/test_grf_inner_boundary_sign_condition.py