### PR TITLE
docs(essay): add rho-minus-pt boundary sign lemma

### DIFF
--- a/artifacts/grf/rho_minus_pt_boundary_lemma.json
+++ b/artifacts/grf/rho_minus_pt_boundary_lemma.json
@@ -1,0 +1,20 @@
+{
+  "status": "ANALYTIC_SIGN_LEMMA",
+  "targeted_margin": "rho_minus_pt",
+  "targeted_cell": "inner boundary cell",
+  "metric": "ds^2=-exp(2 Phi(r))dt^2+beta(r)dr^2+r^2 dOmega^2",
+  "misner_sharp_relation": "beta(r)=1/(1-2m(r)/r)",
+  "beta_log_derivative": "beta'/beta=(2m'/r-2m/r^2)/(1-2m/r)",
+  "rho_minus_pt_formula": "rho-p_t = m'/r^2 - beta^{-1}(Phi''+(Phi')^2-(beta'/(2 beta))Phi'+Phi'/r-beta'/(2 beta r))",
+  "inner_boundary_inequality": "m1p/r1^2 >= (1-2m1/r1)(Phi1pp+Phi1p^2+Phi1p/r1) - (m1p/r1-m1/r1^2)(Phi1p+1/r1)",
+  "radial_nec_saturation_substitution": "Phi1p=beta1*m1p/r1^2",
+  "frontier_use": "Any next interval ansatz must satisfy the inner-boundary inequality before searching the first cell.",
+  "does_not_prove": [
+    "global matching theorem",
+    "positive interval certificate",
+    "WEC/DEC closure",
+    "GRF theorem-level closure",
+    "physical realization theorem"
+  ],
+  "next_missing_object": "first-cell interval extension lemma for rho_minus_pt"
+}

--- a/docs/essays/GRF_2026_RHO_MINUS_PT_BOUNDARY_LEMMA.md
+++ b/docs/essays/GRF_2026_RHO_MINUS_PT_BOUNDARY_LEMMA.md
@@ -1,0 +1,156 @@
+# GRF 2026 — \(\rho-p_t\) Inner-Boundary Sign Lemma
+
+## Status
+
+`ANALYTIC_SIGN_LEMMA`
+
+## Setup
+
+Use the static spherical metric
+
+\[
+ds^2=-e^{2\Phi(r)}dt^2+\beta(r)\,dr^2+r^2d\Omega^2
+\]
+
+with Misner-Sharp relation
+
+\[
+\beta(r)=\frac{1}{1-2m(r)/r}.
+\]
+
+Then
+
+\[
+\frac{\beta'}{\beta}
+=
+\frac{2m'/r-2m/r^2}{1-2m/r}.
+\]
+
+## Tangential-pressure formula
+
+In the normalization used by the GRF probes,
+
+\[
+\rho=\frac{m'}{r^2},
+\]
+
+and
+
+\[
+p_t
+=
+\beta^{-1}
+\left[
+\Phi''
++
+(\Phi')^2
+-
+\frac{\beta'}{2\beta}\Phi'
++
+\frac{\Phi'}{r}
+-
+\frac{\beta'}{2\beta r}
+\right].
+\]
+
+Therefore
+
+\[
+\rho-p_t
+=
+\frac{m'}{r^2}
+-
+\beta^{-1}
+\left[
+\Phi''
++
+(\Phi')^2
+-
+\frac{\beta'}{2\beta}\Phi'
++
+\frac{\Phi'}{r}
+-
+\frac{\beta'}{2\beta r}
+\right].
+\]
+
+## Inner-boundary inequality
+
+At \(r=r_1\), write
+
+\[
+m_1=m(r_1),\quad
+m_1'=m'(r_1),\quad
+\Phi_1'=\Phi'(r_1),\quad
+\Phi_1''=\Phi''(r_1).
+\]
+
+The analytic necessary boundary condition for the first interval cell is
+
+\[
+\frac{m_1'}{r_1^2}
+\ge
+\left(1-\frac{2m_1}{r_1}\right)
+\left[
+\Phi_1''
++
+(\Phi_1')^2
++
+\frac{\Phi_1'}{r_1}
+\right]
+-
+\left(
+\frac{m_1'}{r_1}
+-
+\frac{m_1}{r_1^2}
+\right)
+\left(
+\Phi_1'
++
+\frac{1}{r_1}
+\right).
+\]
+
+Equivalently,
+
+\[
+(\rho-p_t)(r_1)\ge0.
+\]
+
+## Radial NEC saturation substitution
+
+Under radial NEC saturation,
+
+\[
+\rho+p_r=0,
+\]
+
+the redshift derivative used by the probes is
+
+\[
+\Phi_1'
+=
+\beta_1\frac{m_1'}{r_1^2},
+\qquad
+\beta_1=\frac{1}{1-2m_1/r_1}.
+\]
+
+Thus any next ansatz must choose \(\Phi_1''\), or an equivalent second-order redshift-control parameter, so that the displayed inequality is satisfied before interval search.
+
+## Boundary
+
+This is an analytic sign lemma.
+
+It is not a global matching theorem.
+
+It is not a positive interval certificate.
+
+It is not WEC/DEC closure.
+
+It is not GRF theorem-level closure.
+
+It is not a physical realization theorem.
+
+## Next missing object
+
+first-cell interval extension lemma for rho_minus_pt

--- a/scripts/verify_grf_rho_minus_pt_boundary_lemma.py
+++ b/scripts/verify_grf_rho_minus_pt_boundary_lemma.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+DOC = Path("docs/essays/GRF_2026_RHO_MINUS_PT_BOUNDARY_LEMMA.md")
+ART = Path("artifacts/grf/rho_minus_pt_boundary_lemma.json")
+
+for path in (DOC, ART):
+    if not path.exists():
+        raise SystemExit(f"missing required file: {path}")
+
+doc = DOC.read_text(encoding="utf-8")
+for tok in [
+    "ANALYTIC_SIGN_LEMMA",
+    "\\rho-p_t",
+    "beta(r)=\\frac{1}{1-2m(r)/r}",
+    "\\frac{\\beta'}{\\beta}",
+    "p_t",
+    "\\rho-p_t",
+    "\\frac{m_1'}{r_1^2}",
+    "\\Phi_1''",
+    "\\Phi_1'",
+    "(\\rho-p_t)(r_1)\\ge0",
+    "\\Phi_1'",
+    "\\beta_1=\\frac{1}{1-2m_1/r_1}",
+    "\\beta_1\\frac{m_1'}{r_1^2}",
+    "This is an analytic sign lemma.",
+    "It is not a global matching theorem.",
+    "It is not a positive interval certificate.",
+    "It is not WEC/DEC closure.",
+    "It is not GRF theorem-level closure.",
+    "first-cell interval extension lemma for rho_minus_pt",
+]:
+    if tok not in doc:
+        raise SystemExit(f"missing doc token: {tok}")
+
+data = json.loads(ART.read_text(encoding="utf-8"))
+if data["status"] != "ANALYTIC_SIGN_LEMMA":
+    raise SystemExit("bad status")
+if data["targeted_margin"] != "rho_minus_pt":
+    raise SystemExit("bad targeted_margin")
+if data["targeted_cell"] != "inner boundary cell":
+    raise SystemExit("bad targeted_cell")
+if "Phi1pp" not in data["inner_boundary_inequality"]:
+    raise SystemExit("missing Phi1pp in inequality")
+if data["next_missing_object"] != "first-cell interval extension lemma for rho_minus_pt":
+    raise SystemExit("bad next missing object")
+
+for forbidden in [
+    "global matching theorem proved",
+    "positive interval certificate proved",
+    "WEC/DEC closure proved",
+    "GRF theorem-level closure proved",
+    "physical realization theorem proved"
+]:
+    if forbidden in doc or forbidden in json.dumps(data):
+        raise SystemExit(f"forbidden overclaim: {forbidden}")
+
+print("GRF rho-minus-pt boundary lemma verification OK.")

--- a/tests/test_grf_rho_minus_pt_boundary_lemma.py
+++ b/tests/test_grf_rho_minus_pt_boundary_lemma.py
@@ -1,0 +1,15 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_rho_minus_pt_boundary_lemma_artifact():
+    data = json.loads(Path("artifacts/grf/rho_minus_pt_boundary_lemma.json").read_text())
+    assert data["status"] == "ANALYTIC_SIGN_LEMMA"
+    assert data["targeted_margin"] == "rho_minus_pt"
+    assert "Phi1pp" in data["inner_boundary_inequality"]
+    assert data["next_missing_object"] == "first-cell interval extension lemma for rho_minus_pt"
+
+
+def test_rho_minus_pt_boundary_lemma_verifier():
+    subprocess.run(["python3", "scripts/verify_grf_rho_minus_pt_boundary_lemma.py"], check=True)


### PR DESCRIPTION
Adds the analytic rho_minus_pt inner-boundary sign lemma for the GRF transition-shell frontier.

Change:
- Derives the closed-form rho_minus_pt expression.
- Rewrites the inner-boundary inequality in terms of m1, m1p, Phi1p, and Phi1pp.
- Records the radial NEC saturation substitution Phi1p = beta1*m1p/r1^2.
- Adds a JSON artifact, verifier, and regression test.

Boundary:
- This is an analytic sign lemma.
- It is not a global matching theorem.
- It is not a positive interval certificate.
- It is not WEC/DEC closure.
- It is not GRF theorem-level closure.
- It is not a physical realization theorem.

Verification:
- python3 scripts/verify_grf_rho_minus_pt_boundary_lemma.py
- python3 -m pytest -q tests/test_grf_rho_minus_pt_boundary_lemma.py