### PR TITLE
docs(essay): add first-cell interval extension lemma

### DIFF
--- a/artifacts/grf/first_cell_interval_extension_lemma.json
+++ b/artifacts/grf/first_cell_interval_extension_lemma.json
@@ -1,0 +1,19 @@
+{
+  "status": "CONDITIONAL_INTERVAL_EXTENSION_LEMMA",
+  "targeted_margin": "rho_minus_pt",
+  "targeted_cell": "first interval cell",
+  "input_lemma": "rho_minus_pt(r1) >= 0",
+  "required_modulus": "There exists L >= 0 such that |d/dr(rho_minus_pt)(r)| <= L on [r1,r1+dr].",
+  "extension_condition": "rho_minus_pt(r1) - L*dr >= 0",
+  "conclusion": "inf_{r in [r1,r1+dr]} rho_minus_pt(r) >= 0",
+  "frontier_use": "A future interval certificate may close the first cell by proving an explicit lower endpoint margin and a derivative modulus bound.",
+  "does_not_prove": [
+    "existence of L for the GRF transition ansatz",
+    "positive interval certificate",
+    "global matching theorem",
+    "WEC/DEC closure",
+    "GRF theorem-level closure",
+    "physical realization theorem"
+  ],
+  "next_missing_object": "explicit derivative-modulus bound for rho_minus_pt on the first cell"
+}

--- a/docs/essays/GRF_2026_FIRST_CELL_INTERVAL_EXTENSION_LEMMA.md
+++ b/docs/essays/GRF_2026_FIRST_CELL_INTERVAL_EXTENSION_LEMMA.md
@@ -1,0 +1,117 @@
+# GRF 2026 — First-Cell Interval Extension Lemma
+
+## Status
+
+`CONDITIONAL_INTERVAL_EXTENSION_LEMMA`
+
+## Target
+
+The remaining obstruction is the first-cell interval lower bound for
+
+\[
+\rho-p_t.
+\]
+
+The target cell is
+
+\[
+I_1=[r_1,r_1+\Delta r].
+\]
+
+## Conditional lemma
+
+Let
+
+\[
+f(r)=\rho(r)-p_t(r).
+\]
+
+Assume:
+
+\[
+f(r_1)\ge \eta
+\]
+
+and
+
+\[
+|f'(r)|\le L
+\qquad
+\text{for all }r\in[r_1,r_1+\Delta r].
+\]
+
+If
+
+\[
+\eta-L\Delta r\ge0,
+\]
+
+then
+
+\[
+\inf_{r\in[r_1,r_1+\Delta r]} f(r)\ge0.
+\]
+
+Equivalently,
+
+\[
+\inf_{r\in[r_1,r_1+\Delta r]}(\rho-p_t)(r)\ge0.
+\]
+
+## Proof
+
+For \(r\in[r_1,r_1+\Delta r]\), the mean-value inequality gives
+
+\[
+f(r)\ge f(r_1)-L|r-r_1|.
+\]
+
+Since \(|r-r_1|\le\Delta r\),
+
+\[
+f(r)\ge\eta-L\Delta r.
+\]
+
+Thus, if \(\eta-L\Delta r\ge0\),
+
+\[
+f(r)\ge0
+\]
+
+throughout the first cell.
+
+## Frontier use
+
+The next interval ansatz must provide:
+
+\[
+\eta=(\rho-p_t)(r_1)>0
+\]
+
+and a certified derivative-modulus bound
+
+\[
+|(\rho-p_t)'(r)|\le L
+\]
+
+on the first cell.
+
+## Boundary
+
+This is a conditional interval extension lemma.
+
+It is not an existence proof for the derivative-modulus bound.
+
+It is not a positive interval certificate.
+
+It is not a global matching theorem.
+
+It is not WEC/DEC closure.
+
+It is not GRF theorem-level closure.
+
+It is not a physical realization theorem.
+
+## Next missing object
+
+explicit derivative-modulus bound for rho_minus_pt on the first cell

--- a/scripts/verify_grf_first_cell_interval_extension_lemma.py
+++ b/scripts/verify_grf_first_cell_interval_extension_lemma.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+DOC = Path("docs/essays/GRF_2026_FIRST_CELL_INTERVAL_EXTENSION_LEMMA.md")
+ART = Path("artifacts/grf/first_cell_interval_extension_lemma.json")
+
+for path in (DOC, ART):
+    if not path.exists():
+        raise SystemExit(f"missing required file: {path}")
+
+doc = DOC.read_text(encoding="utf-8")
+for tok in [
+    "CONDITIONAL_INTERVAL_EXTENSION_LEMMA",
+    "\\rho-p_t",
+    "I_1=[r_1,r_1+\\Delta r]",
+    "f(r)=\\rho(r)-p_t(r)",
+    "f(r_1)\\ge \\eta",
+    "|f'(r)|\\le L",
+    "\\eta-L\\Delta r\\ge0",
+    "\\inf_{r\\in[r_1,r_1+\\Delta r]} f(r)\\ge0",
+    "mean-value inequality",
+    "explicit derivative-modulus bound for rho_minus_pt on the first cell",
+    "This is a conditional interval extension lemma.",
+    "It is not an existence proof for the derivative-modulus bound.",
+    "It is not a positive interval certificate.",
+    "It is not a global matching theorem.",
+    "It is not WEC/DEC closure.",
+    "It is not GRF theorem-level closure."
+]:
+    if tok not in doc:
+        raise SystemExit(f"missing doc token: {tok}")
+
+data = json.loads(ART.read_text(encoding="utf-8"))
+if data["status"] != "CONDITIONAL_INTERVAL_EXTENSION_LEMMA":
+    raise SystemExit("bad status")
+if data["targeted_margin"] != "rho_minus_pt":
+    raise SystemExit("bad targeted_margin")
+if data["targeted_cell"] != "first interval cell":
+    raise SystemExit("bad targeted_cell")
+if data["extension_condition"] != "rho_minus_pt(r1) - L*dr >= 0":
+    raise SystemExit("bad extension condition")
+if data["next_missing_object"] != "explicit derivative-modulus bound for rho_minus_pt on the first cell":
+    raise SystemExit("bad next missing object")
+
+for forbidden in [
+    "positive interval certificate proved",
+    "global matching theorem proved",
+    "WEC/DEC closure proved",
+    "GRF theorem-level closure proved",
+    "physical realization theorem proved"
+]:
+    if forbidden in doc or forbidden in json.dumps(data):
+        raise SystemExit(f"forbidden overclaim: {forbidden}")
+
+print("GRF first-cell interval extension lemma verification OK.")

--- a/tests/test_grf_first_cell_interval_extension_lemma.py
+++ b/tests/test_grf_first_cell_interval_extension_lemma.py
@@ -1,0 +1,16 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_first_cell_interval_extension_lemma_artifact():
+    data = json.loads(Path("artifacts/grf/first_cell_interval_extension_lemma.json").read_text())
+    assert data["status"] == "CONDITIONAL_INTERVAL_EXTENSION_LEMMA"
+    assert data["targeted_margin"] == "rho_minus_pt"
+    assert data["targeted_cell"] == "first interval cell"
+    assert data["extension_condition"] == "rho_minus_pt(r1) - L*dr >= 0"
+    assert data["next_missing_object"] == "explicit derivative-modulus bound for rho_minus_pt on the first cell"
+
+
+def test_first_cell_interval_extension_lemma_verifier():
+    subprocess.run(["python3", "scripts/verify_grf_first_cell_interval_extension_lemma.py"], check=True)


### PR DESCRIPTION
Adds the conditional first-cell interval extension lemma for the GRF transition-shell frontier.

Change:
- Defines f(r)=rho_minus_pt.
- Proves the conditional extension criterion f(r1) >= eta, |f'| <= L, and eta - L*dr >= 0.
- Identifies the next missing object as an explicit derivative-modulus bound for rho_minus_pt on the first cell.
- Adds a JSON artifact, verifier, and regression test.

Boundary:
- This is a conditional interval extension lemma.
- It is not an existence proof for the derivative-modulus bound.
- It is not a positive interval certificate.
- It is not a global matching theorem.
- It is not WEC/DEC closure.
- It is not GRF theorem-level closure.
- It is not a physical realization theorem.

Verification:
- python3 scripts/verify_grf_first_cell_interval_extension_lemma.py
- python3 -m pytest -q tests/test_grf_first_cell_interval_extension_lemma.py