### PR TITLE
docs(essay): add first-cell derivative modulus bound

### DIFF
--- a/artifacts/grf/first_cell_derivative_modulus_bound.json
+++ b/artifacts/grf/first_cell_derivative_modulus_bound.json
@@ -1,0 +1,23 @@
+{
+  "id": "GRF_2026_FIRST_CELL_DERIVATIVE_MODULUS_BOUND",
+  "title": "First-cell derivative modulus bound for rho_minus_pt",
+  "status": "CONDITIONAL_DERIVATIVE_MODULUS_BOUND",
+  "result": "If the first-cell compactness data give r >= r0 > 0, A = 1 - 2m/r >= a > 0, and uniform bounds on |m|, |m'|, |m''|, |Phi'|, |Phi''|, |Phi'''|, then |d(rho_minus_pt)/dr| <= L_cell on the first cell.",
+  "minimal_missing_assumption_closed": "FirstCellDerivativeData(r0,a,M0,M1,M2,P1,P2,P3)",
+  "feeds": [
+    "GRF_2026_FIRST_CELL_INTERVAL_EXTENSION_LEMMA"
+  ],
+  "boundary": [
+    "conditional derivative modulus only",
+    "not a proof that the derivative data exist",
+    "not a positive interval certificate",
+    "not a global matching theorem",
+    "not WEC/DEC closure",
+    "not GRF theorem-level closure",
+    "not a physical realization theorem"
+  ],
+  "verification": [
+    "python3 scripts/verify_grf_first_cell_derivative_modulus_bound.py",
+    "python3 -m pytest -q tests/test_grf_first_cell_derivative_modulus_bound.py"
+  ]
+}

--- a/docs/essays/GRF_2026_FIRST_CELL_DERIVATIVE_MODULUS_BOUND.md
+++ b/docs/essays/GRF_2026_FIRST_CELL_DERIVATIVE_MODULUS_BOUND.md
@@ -1,0 +1,235 @@
+# GRF First-Cell Derivative Modulus Bound
+
+Status: `CONDITIONAL_DERIVATIVE_MODULUS_BOUND`
+
+## Object
+
+Let
+
+\[
+A(r)=1-\frac{2m(r)}{r},
+\qquad
+B(r)=\frac{r m'(r)-m(r)}{r^2 A(r)}.
+\]
+
+Use the standard transition-shell expression
+
+\[
+\rho-p_t
+=
+\frac{m'}{4\pi r^2}
+-
+\frac{A}{8\pi}
+\left(
+\Phi''
++(\Phi')^2
++\frac{\Phi'}{r}
+-
+B\left(\Phi'+\frac1r\right)
+\right).
+\]
+
+Set
+
+\[
+Q
+=
+\Phi''
++(\Phi')^2
++\frac{\Phi'}{r}
+-
+B\left(\Phi'+\frac1r\right).
+\]
+
+Then
+
+\[
+(\rho-p_t)'
+=
+\frac1{4\pi}
+\left(
+\frac{m''}{r^2}
+-
+\frac{2m'}{r^3}
+\right)
+-
+\frac1{8\pi}
+\left(A'Q+AQ'\right),
+\]
+
+where
+
+\[
+A'=-\frac{2m'}r+\frac{2m}{r^2},
+\]
+
+\[
+B'
+=
+\frac{(r m'')(r^2A)-(r m'-m)(2r-2m-2rm')}{(r^2A)^2},
+\]
+
+and
+
+\[
+Q'
+=
+\Phi'''
++2\Phi'\Phi''
++\frac{\Phi''}{r}
+-\frac{\Phi'}{r^2}
+-
+B'\left(\Phi'+\frac1r\right)
+-
+B\left(\Phi''-\frac1{r^2}\right).
+\]
+
+## Conditional bound
+
+Fix a first cell
+
+\[
+I=[r_1,r_1+\Delta r].
+\]
+
+Assume first-cell derivative data
+
+\[
+r\ge r_0>0,
+\qquad
+A(r)\ge a>0,
+\]
+
+and
+
+\[
+|m|\le M_0,\quad
+|m'|\le M_1,\quad
+|m''|\le M_2,
+\]
+
+\[
+|\Phi'|\le P_1,\quad
+|\Phi''|\le P_2,\quad
+|\Phi'''|\le P_3
+\]
+
+on \(I\). Let
+
+\[
+R=r_1+\Delta r,
+\]
+
+\[
+A_{\max}=1+\frac{2M_0}{r_0},
+\qquad
+A_1=\frac{2M_1}{r_0}+\frac{2M_0}{r_0^2},
+\]
+
+\[
+N_{\max}=RM_1+M_0,
+\qquad
+D_1=2R+2M_0+2RM_1,
+\]
+
+\[
+B_{\max}
+=
+\frac{N_{\max}}{r_0^2a},
+\]
+
+\[
+B_1
+=
+\frac{(RM_2)(R^2A_{\max})+N_{\max}D_1}{r_0^4a^2}.
+\]
+
+Define
+
+\[
+Q_{\max}
+=
+P_2+P_1^2+\frac{P_1}{r_0}
++
+B_{\max}\left(P_1+\frac1{r_0}\right),
+\]
+
+\[
+Q_1
+=
+P_3+2P_1P_2+\frac{P_2}{r_0}+\frac{P_1}{r_0^2}
++
+B_1\left(P_1+\frac1{r_0}\right)
++
+B_{\max}\left(P_2+\frac1{r_0^2}\right).
+\]
+
+Then the first-cell derivative modulus is
+
+\[
+L_{\rm cell}
+=
+\frac1{4\pi}
+\left(
+\frac{M_2}{r_0^2}
++
+\frac{2M_1}{r_0^3}
+\right)
++
+\frac1{8\pi}
+\left(
+A_1Q_{\max}+A_{\max}Q_1
+\right).
+\]
+
+Hence
+
+\[
+\forall r\in I,\qquad
+\left|
+\frac{d}{dr}(\rho-p_t)(r)
+\right|
+\le
+L_{\rm cell}.
+\]
+
+## Interface closure
+
+This supplies the missing object required by the first-cell interval extension lemma:
+
+\[
+\mathrm{FirstCellDerivativeModulusBound}
+(\rho-p_t,r_1,\Delta r,L_{\rm cell}).
+\]
+
+Consequently, if the previous boundary lemma supplies
+
+\[
+(\rho-p_t)(r_1)\ge \eta
+\]
+
+and
+
+\[
+\eta-L_{\rm cell}\Delta r\ge0,
+\]
+
+then
+
+\[
+\rho-p_t\ge0
+\]
+
+on the first cell.
+
+## Boundary
+
+This is a conditional derivative modulus only.
+
+It does not prove:
+- existence of the first-cell derivative data,
+- a positive interval certificate,
+- a global matching theorem,
+- WEC/DEC closure,
+- GRF theorem-level closure,
+- a physical realization theorem.

--- a/scripts/verify_grf_first_cell_derivative_modulus_bound.py
+++ b/scripts/verify_grf_first_cell_derivative_modulus_bound.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs/essays/GRF_2026_FIRST_CELL_DERIVATIVE_MODULUS_BOUND.md"
+ART = ROOT / "artifacts/grf/first_cell_derivative_modulus_bound.json"
+
+REQUIRED_DOC_TOKENS = [
+    "Status: `CONDITIONAL_DERIVATIVE_MODULUS_BOUND`",
+    "FirstCellDerivativeModulusBound",
+    "L_{\\rm cell}",
+    "A(r)=1-\\frac{2m(r)}{r}",
+    "B(r)=\\frac{r m'(r)-m(r)}{r^2 A(r)}",
+    "Q'",
+    "\\Phi'''",
+    "\\eta-L_{\\rm cell}\\Delta r\\ge0",
+    "It does not prove:",
+    "GRF theorem-level closure",
+]
+
+REQUIRED_ARTIFACT_FIELDS = {
+    "id": "GRF_2026_FIRST_CELL_DERIVATIVE_MODULUS_BOUND",
+    "status": "CONDITIONAL_DERIVATIVE_MODULUS_BOUND",
+    "minimal_missing_assumption_closed": "FirstCellDerivativeData(r0,a,M0,M1,M2,P1,P2,P3)",
+}
+
+
+def main() -> None:
+    if not DOC.exists():
+        raise SystemExit(f"missing doc: {DOC}")
+    if not ART.exists():
+        raise SystemExit(f"missing artifact: {ART}")
+
+    doc = DOC.read_text(encoding="utf-8")
+    for token in REQUIRED_DOC_TOKENS:
+        if token not in doc:
+            raise SystemExit(f"missing doc token: {token}")
+
+    artifact = json.loads(ART.read_text(encoding="utf-8"))
+    for key, expected in REQUIRED_ARTIFACT_FIELDS.items():
+        actual = artifact.get(key)
+        if actual != expected:
+            raise SystemExit(f"bad artifact field {key}: expected {expected!r}, got {actual!r}")
+
+    boundary = "\n".join(artifact.get("boundary", []))
+    for token in [
+        "conditional derivative modulus only",
+        "not a proof that the derivative data exist",
+        "not WEC/DEC closure",
+        "not GRF theorem-level closure",
+    ]:
+        if token not in boundary:
+            raise SystemExit(f"missing boundary token: {token}")
+
+    print("GRF first-cell derivative modulus bound verification OK.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_grf_first_cell_derivative_modulus_bound.py
+++ b/tests/test_grf_first_cell_derivative_modulus_bound.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import json
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_first_cell_derivative_modulus_bound_verifier_passes():
+    result = subprocess.run(
+        [sys.executable, "scripts/verify_grf_first_cell_derivative_modulus_bound.py"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert "verification OK" in result.stdout
+
+
+def test_first_cell_derivative_modulus_bound_artifact_boundary():
+    artifact = json.loads(
+        (ROOT / "artifacts/grf/first_cell_derivative_modulus_bound.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert artifact["status"] == "CONDITIONAL_DERIVATIVE_MODULUS_BOUND"
+    assert artifact["minimal_missing_assumption_closed"] == (
+        "FirstCellDerivativeData(r0,a,M0,M1,M2,P1,P2,P3)"
+    )
+    assert "GRF_2026_FIRST_CELL_INTERVAL_EXTENSION_LEMMA" in artifact["feeds"]
+    assert any("not GRF theorem-level closure" in item for item in artifact["boundary"])


### PR DESCRIPTION
Adds the conditional derivative-modulus bound required by the first-cell interval extension lemma.

Change:
- Defines A, B, Q, Qprime, and the closed first-cell derivative formula for rho_minus_pt.
- Gives an explicit L_cell bound from first-cell derivative data.
- Wires L_cell into the existing eta - L*dr >= 0 interval-extension criterion.
- Adds a JSON artifact, verifier, and regression test.

Boundary:
- Conditional derivative modulus only.
- Not a proof that the derivative data exist.
- Not a positive interval certificate.
- Not a global matching theorem.
- Not WEC/DEC closure.
- Not GRF theorem-level closure.
- Not a physical realization theorem.

Verification:
- python3 scripts/verify_grf_first_cell_derivative_modulus_bound.py
- python3 -m pytest -q tests/test_grf_first_cell_derivative_modulus_bound.py