### PR TITLE
docs(essay): add first-cell positivity certificate

### DIFF
--- a/artifacts/grf/first_cell_positivity_certificate.json
+++ b/artifacts/grf/first_cell_positivity_certificate.json
@@ -1,0 +1,27 @@
+{
+  "id": "GRF_2026_FIRST_CELL_POSITIVITY_CERTIFICATE",
+  "title": "First-cell positivity certificate for rho_minus_pt",
+  "status": "CONDITIONAL_FIRST_CELL_CERTIFICATE",
+  "result": "If rho_minus_pt(r1) >= eta, FirstCellDerivativeModulusBound(rho_minus_pt,r1,dr,L_cell), and eta - L_cell*dr >= 0, then rho_minus_pt >= 0 on [r1,r1+dr].",
+  "inputs": [
+    "GRF_2026_INNER_BOUNDARY_SIGN_CONDITION",
+    "GRF_2026_RHO_MINUS_PT_BOUNDARY_LEMMA",
+    "GRF_2026_FIRST_CELL_INTERVAL_EXTENSION_LEMMA",
+    "GRF_2026_FIRST_CELL_DERIVATIVE_MODULUS_BOUND"
+  ],
+  "minimal_missing_assumption_closed": "FirstCellCertificateData(eta,dr,L_cell)",
+  "boundary": [
+    "conditional first-cell certificate only",
+    "not a proof that eta is positive",
+    "not a proof that L_cell derivative data exist",
+    "not a multi-cell interval certificate",
+    "not a global matching theorem",
+    "not WEC/DEC closure",
+    "not GRF theorem-level closure",
+    "not a physical realization theorem"
+  ],
+  "verification": [
+    "python3 scripts/verify_grf_first_cell_positivity_certificate.py",
+    "python3 -m pytest -q tests/test_grf_first_cell_positivity_certificate.py"
+  ]
+}

--- a/docs/essays/GRF_2026_FIRST_CELL_POSITIVITY_CERTIFICATE.md
+++ b/docs/essays/GRF_2026_FIRST_CELL_POSITIVITY_CERTIFICATE.md
@@ -1,0 +1,118 @@
+# GRF First-Cell Positivity Certificate
+
+Status: `CONDITIONAL_FIRST_CELL_CERTIFICATE`
+
+## Object
+
+Let
+
+\[
+f(r)=\rho-p_t.
+\]
+
+Fix the first cell
+
+\[
+I=[r_1,r_1+\Delta r].
+\]
+
+Assume the boundary margin
+
+\[
+f(r_1)\ge \eta.
+\]
+
+Assume the derivative modulus bound
+
+\[
+\forall r\in I,\qquad |f'(r)|\le L_{\rm cell}.
+\]
+
+Assume the cell-width condition
+
+\[
+\eta-L_{\rm cell}\Delta r\ge0.
+\]
+
+Then
+
+\[
+\forall r\in I,\qquad f(r)\ge0.
+\]
+
+Equivalently,
+
+\[
+\forall r\in [r_1,r_1+\Delta r],
+\qquad
+\rho(r)-p_t(r)\ge0.
+\]
+
+## Proof skeleton
+
+For any \(r\in I\), the mean-value estimate gives
+
+\[
+f(r)\ge f(r_1)-L_{\rm cell}|r-r_1|.
+\]
+
+Since
+
+\[
+|r-r_1|\le\Delta r,
+\]
+
+we get
+
+\[
+f(r)\ge \eta-L_{\rm cell}\Delta r.
+\]
+
+By the certificate condition,
+
+\[
+\eta-L_{\rm cell}\Delta r\ge0.
+\]
+
+Therefore
+
+\[
+f(r)\ge0
+\]
+
+throughout the first cell.
+
+## Certificate schema
+
+A first-cell positivity certificate consists of the tuple
+
+\[
+(r_1,\Delta r,\eta,L_{\rm cell})
+\]
+
+with
+
+\[
+\eta\ge0,
+\qquad
+L_{\rm cell}\ge0,
+\qquad
+\Delta r\ge0,
+\qquad
+\eta-L_{\rm cell}\Delta r\ge0.
+\]
+
+The certificate closes only the first-cell nonnegativity implication.
+
+## Boundary
+
+This is a conditional first-cell certificate only.
+
+It does not prove:
+- that \(\eta\) is positive,
+- that the derivative data defining \(L_{\rm cell}\) exist,
+- a multi-cell interval certificate,
+- a global matching theorem,
+- WEC/DEC closure,
+- GRF theorem-level closure,
+- a physical realization theorem.

--- a/scripts/verify_grf_first_cell_positivity_certificate.py
+++ b/scripts/verify_grf_first_cell_positivity_certificate.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs/essays/GRF_2026_FIRST_CELL_POSITIVITY_CERTIFICATE.md"
+ART = ROOT / "artifacts/grf/first_cell_positivity_certificate.json"
+
+REQUIRED_DOC_TOKENS = [
+    "Status: `CONDITIONAL_FIRST_CELL_CERTIFICATE`",
+    "f(r)=\\rho-p_t",
+    "I=[r_1,r_1+\\Delta r]",
+    "f(r_1)\\ge \\eta",
+    "|f'(r)|\\le L_{\\rm cell}",
+    "\\eta-L_{\\rm cell}\\Delta r\\ge0",
+    "\\rho(r)-p_t(r)\\ge0",
+    "mean-value estimate",
+    "It does not prove:",
+    "GRF theorem-level closure",
+]
+
+REQUIRED_ARTIFACT_FIELDS = {
+    "id": "GRF_2026_FIRST_CELL_POSITIVITY_CERTIFICATE",
+    "status": "CONDITIONAL_FIRST_CELL_CERTIFICATE",
+    "minimal_missing_assumption_closed": "FirstCellCertificateData(eta,dr,L_cell)",
+}
+
+
+def main() -> None:
+    if not DOC.exists():
+        raise SystemExit(f"missing doc: {DOC}")
+    if not ART.exists():
+        raise SystemExit(f"missing artifact: {ART}")
+
+    doc = DOC.read_text(encoding="utf-8")
+    for token in REQUIRED_DOC_TOKENS:
+        if token not in doc:
+            raise SystemExit(f"missing doc token: {token}")
+
+    artifact = json.loads(ART.read_text(encoding="utf-8"))
+    for key, expected in REQUIRED_ARTIFACT_FIELDS.items():
+        actual = artifact.get(key)
+        if actual != expected:
+            raise SystemExit(f"bad artifact field {key}: expected {expected!r}, got {actual!r}")
+
+    required_inputs = {
+        "GRF_2026_INNER_BOUNDARY_SIGN_CONDITION",
+        "GRF_2026_RHO_MINUS_PT_BOUNDARY_LEMMA",
+        "GRF_2026_FIRST_CELL_INTERVAL_EXTENSION_LEMMA",
+        "GRF_2026_FIRST_CELL_DERIVATIVE_MODULUS_BOUND",
+    }
+    inputs = set(artifact.get("inputs", []))
+    missing = required_inputs - inputs
+    if missing:
+        raise SystemExit(f"missing artifact inputs: {sorted(missing)}")
+
+    boundary = "\n".join(artifact.get("boundary", []))
+    for token in [
+        "conditional first-cell certificate only",
+        "not a proof that eta is positive",
+        "not a proof that L_cell derivative data exist",
+        "not WEC/DEC closure",
+        "not GRF theorem-level closure",
+    ]:
+        if token not in boundary:
+            raise SystemExit(f"missing boundary token: {token}")
+
+    print("GRF first-cell positivity certificate verification OK.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_grf_first_cell_positivity_certificate.py
+++ b/tests/test_grf_first_cell_positivity_certificate.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import json
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_first_cell_positivity_certificate_verifier_passes():
+    result = subprocess.run(
+        [sys.executable, "scripts/verify_grf_first_cell_positivity_certificate.py"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert "verification OK" in result.stdout
+
+
+def test_first_cell_positivity_certificate_artifact_boundary():
+    artifact = json.loads(
+        (ROOT / "artifacts/grf/first_cell_positivity_certificate.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert artifact["status"] == "CONDITIONAL_FIRST_CELL_CERTIFICATE"
+    assert artifact["minimal_missing_assumption_closed"] == (
+        "FirstCellCertificateData(eta,dr,L_cell)"
+    )
+    assert "GRF_2026_FIRST_CELL_INTERVAL_EXTENSION_LEMMA" in artifact["inputs"]
+    assert "GRF_2026_FIRST_CELL_DERIVATIVE_MODULUS_BOUND" in artifact["inputs"]
+    assert any("not GRF theorem-level closure" in item for item in artifact["boundary"])


### PR DESCRIPTION
Adds the conditional first-cell positivity certificate for the GRF transition-shell frontier.

Change:
- Packages the boundary margin eta and derivative modulus L_cell.
- Proves the first-cell implication eta - L_cell*dr >= 0 => rho_minus_pt >= 0 on the first cell.
- Connects the inner-boundary sign condition, rho_minus_pt boundary lemma, interval extension lemma, and derivative modulus bound.
- Adds a JSON artifact, verifier, and regression test.

Boundary:
- Conditional first-cell certificate only.
- Not a proof that eta is positive.
- Not a proof that L_cell derivative data exist.
- Not a multi-cell interval certificate.
- Not a global matching theorem.
- Not WEC/DEC closure.
- Not GRF theorem-level closure.
- Not a physical realization theorem.

Verification:
- python3 scripts/verify_grf_first_cell_positivity_certificate.py
- python3 -m pytest -q tests/test_grf_first_cell_positivity_certificate.py