### PR TITLE
docs(essay): add GRF full-solve certificate gate

### DIFF
--- a/artifacts/grf/full_solve_certificate_gate.json
+++ b/artifacts/grf/full_solve_certificate_gate.json
@@ -1,0 +1,65 @@
+{
+  "id": "GRF_2026_FULL_SOLVE_CERTIFICATE_GATE",
+  "title": "GRF transition-shell full-solve certificate gate",
+  "status": "FRONTIER_OPEN_FULL_CERTIFICATE_GATE",
+  "result": "Defines the executable obligation gate for a full GRF transition-shell solve. The gate remains open until all eight certificate obligations are supplied and verified.",
+  "required_obligations": [
+    {
+      "id": "O1_POSITIVE_INNER_BOUNDARY_MARGIN",
+      "required_object": "rho_minus_pt(r1) >= eta > 0",
+      "status": "MISSING_NUMERIC_OR_SYMBOLIC_CERTIFICATE"
+    },
+    {
+      "id": "O2_ACTUAL_DERIVATIVE_DATA",
+      "required_object": "bounds on m, m', m'', Phi', Phi'', Phi''' producing concrete L_cell",
+      "status": "MISSING_DERIVATIVE_BOUND_CERTIFICATE"
+    },
+    {
+      "id": "O3_FIRST_CELL_NUMERIC_CERTIFICATE",
+      "required_object": "eta - L_cell*dr >= 0",
+      "status": "MISSING_FIRST_CELL_NUMERIC_CERTIFICATE"
+    },
+    {
+      "id": "O4_MULTI_CELL_PROPAGATION",
+      "required_object": "certified interval propagation across the full transition shell",
+      "status": "MISSING_MULTI_CELL_CERTIFICATE"
+    },
+    {
+      "id": "O5_ALL_WEC_DEC_COMPONENTS",
+      "required_object": "all required WEC/DEC component inequalities verified",
+      "status": "MISSING_COMPONENT_INVENTORY_CERTIFICATES"
+    },
+    {
+      "id": "O6_MATCHING_THEOREM",
+      "required_object": "inner-shell-outer smooth matching with required regularity",
+      "status": "MISSING_MATCHING_CERTIFICATE"
+    },
+    {
+      "id": "O7_PHYSICAL_REALIZATION",
+      "required_object": "admissible geometry/matter realization for chosen functions and parameters",
+      "status": "MISSING_REALIZATION_CERTIFICATE"
+    },
+    {
+      "id": "O8_FORMAL_VERIFICATION",
+      "required_object": "executable final certificate package with no overclaim boundary",
+      "status": "MISSING_FINAL_EXECUTABLE_CERTIFICATE"
+    }
+  ],
+  "certificate_input_path": "artifacts/grf/transition_shell_full_certificate_input.json",
+  "closure_rule": "GRF theorem-level closure is forbidden unless every required obligation has status VERIFIED and the executable certificate checker passes.",
+  "boundary": [
+    "certificate gate only",
+    "not a positive inner-boundary margin proof",
+    "not derivative data construction",
+    "not a first-cell numeric certificate",
+    "not a multi-cell interval certificate",
+    "not WEC/DEC closure",
+    "not a matching theorem",
+    "not a physical realization theorem",
+    "not GRF theorem-level closure"
+  ],
+  "verification": [
+    "python3 scripts/verify_grf_full_solve_certificate_gate.py",
+    "python3 -m pytest -q tests/test_grf_full_solve_certificate_gate.py"
+  ]
+}

--- a/docs/essays/GRF_2026_FULL_SOLVE_CERTIFICATE_GATE.md
+++ b/docs/essays/GRF_2026_FULL_SOLVE_CERTIFICATE_GATE.md
@@ -1,0 +1,108 @@
+# GRF Full-Solve Certificate Gate
+
+Status: `FRONTIER_OPEN_FULL_CERTIFICATE_GATE`
+
+## Gate
+
+A full GRF transition-shell solve requires all eight obligations below.
+
+### O1. Positive inner-boundary margin
+
+Required object:
+
+\[
+\rho(r_1)-p_t(r_1)\ge \eta>0.
+\]
+
+Status: `MISSING_NUMERIC_OR_SYMBOLIC_CERTIFICATE`.
+
+### O2. Actual derivative data
+
+Required object:
+
+\[
+|m|\le M_0,\quad |m'|\le M_1,\quad |m''|\le M_2,
+\]
+
+\[
+|\Phi'|\le P_1,\quad |\Phi''|\le P_2,\quad |\Phi'''|\le P_3.
+\]
+
+These bounds must produce a concrete \(L_{\rm cell}\).
+
+Status: `MISSING_DERIVATIVE_BOUND_CERTIFICATE`.
+
+### O3. First-cell numeric certificate
+
+Required object:
+
+\[
+\eta-L_{\rm cell}\Delta r\ge0.
+\]
+
+Status: `MISSING_FIRST_CELL_NUMERIC_CERTIFICATE`.
+
+### O4. Multi-cell propagation
+
+Required object:
+
+\[
+\forall j,\qquad
+\eta_j-L_j\Delta r_j\ge0,
+\]
+
+with cells covering the whole transition shell.
+
+Status: `MISSING_MULTI_CELL_CERTIFICATE`.
+
+### O5. All WEC/DEC components
+
+Required object: verified certificates for every required WEC/DEC component, not only
+
+\[
+\rho-p_t\ge0.
+\]
+
+Status: `MISSING_COMPONENT_INVENTORY_CERTIFICATES`.
+
+### O6. Matching theorem
+
+Required object: inner region, transition shell, and outer region glue with the required regularity.
+
+Status: `MISSING_MATCHING_CERTIFICATE`.
+
+### O7. Physical realization
+
+Required object: the chosen \(m(r)\), \(\Phi(r)\), shell width, and parameters define an admissible geometry/matter model.
+
+Status: `MISSING_REALIZATION_CERTIFICATE`.
+
+### O8. Formal verification
+
+Required object: an executable certificate package.
+
+The expected input path is
+
+\[
+\texttt{artifacts/grf/transition\_shell\_full\_certificate\_input.json}.
+\]
+
+Status: `MISSING_FINAL_EXECUTABLE_CERTIFICATE`.
+
+## Closure rule
+
+GRF theorem-level closure is forbidden unless every required obligation is marked `VERIFIED` and the executable certificate checker passes.
+
+## Boundary
+
+This is a certificate gate only.
+
+It does not prove:
+- a positive inner-boundary margin,
+- derivative data construction,
+- a first-cell numeric certificate,
+- a multi-cell interval certificate,
+- WEC/DEC closure,
+- a matching theorem,
+- a physical realization theorem,
+- GRF theorem-level closure.

--- a/scripts/verify_grf_full_solve_certificate_gate.py
+++ b/scripts/verify_grf_full_solve_certificate_gate.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ART = ROOT / "artifacts/grf/full_solve_certificate_gate.json"
+DOC = ROOT / "docs/essays/GRF_2026_FULL_SOLVE_CERTIFICATE_GATE.md"
+
+REQUIRED_OBLIGATIONS = {
+    "O1_POSITIVE_INNER_BOUNDARY_MARGIN",
+    "O2_ACTUAL_DERIVATIVE_DATA",
+    "O3_FIRST_CELL_NUMERIC_CERTIFICATE",
+    "O4_MULTI_CELL_PROPAGATION",
+    "O5_ALL_WEC_DEC_COMPONENTS",
+    "O6_MATCHING_THEOREM",
+    "O7_PHYSICAL_REALIZATION",
+    "O8_FORMAL_VERIFICATION",
+}
+
+REQUIRED_DOC_TOKENS = [
+    "Status: `FRONTIER_OPEN_FULL_CERTIFICATE_GATE`",
+    "\\rho(r_1)-p_t(r_1)\\ge \\eta>0",
+    "MISSING_DERIVATIVE_BOUND_CERTIFICATE",
+    "\\eta-L_{\\rm cell}\\Delta r\\ge0",
+    "MISSING_MULTI_CELL_CERTIFICATE",
+    "MISSING_COMPONENT_INVENTORY_CERTIFICATES",
+    "MISSING_MATCHING_CERTIFICATE",
+    "MISSING_REALIZATION_CERTIFICATE",
+    "artifacts/grf/transition\\_shell\\_full\\_certificate\\_input.json",
+    "GRF theorem-level closure is forbidden",
+    "It does not prove:",
+]
+
+REQUIRED_BOUNDARY_TOKENS = [
+    "certificate gate only",
+    "not a positive inner-boundary margin proof",
+    "not derivative data construction",
+    "not a first-cell numeric certificate",
+    "not a multi-cell interval certificate",
+    "not WEC/DEC closure",
+    "not a matching theorem",
+    "not a physical realization theorem",
+    "not GRF theorem-level closure",
+]
+
+
+def main() -> None:
+    if not ART.exists():
+        raise SystemExit(f"missing artifact: {ART}")
+    if not DOC.exists():
+        raise SystemExit(f"missing doc: {DOC}")
+
+    artifact = json.loads(ART.read_text(encoding="utf-8"))
+    if artifact.get("status") != "FRONTIER_OPEN_FULL_CERTIFICATE_GATE":
+        raise SystemExit("gate status must remain FRONTIER_OPEN_FULL_CERTIFICATE_GATE")
+
+    obligations = artifact.get("required_obligations", [])
+    found = {item.get("id") for item in obligations}
+    missing = REQUIRED_OBLIGATIONS - found
+    extra = found - REQUIRED_OBLIGATIONS
+    if missing:
+        raise SystemExit(f"missing obligations: {sorted(missing)}")
+    if extra:
+        raise SystemExit(f"unexpected obligations: {sorted(extra)}")
+
+    for item in obligations:
+        status = item.get("status", "")
+        if not status.startswith("MISSING_"):
+            raise SystemExit(f"obligation must remain missing until certified: {item}")
+
+    boundary = "\n".join(artifact.get("boundary", []))
+    for token in REQUIRED_BOUNDARY_TOKENS:
+        if token not in boundary:
+            raise SystemExit(f"missing boundary token: {token}")
+
+    if artifact.get("certificate_input_path") != "artifacts/grf/transition_shell_full_certificate_input.json":
+        raise SystemExit("bad certificate input path")
+
+    doc = DOC.read_text(encoding="utf-8")
+    for token in REQUIRED_DOC_TOKENS:
+        if token not in doc:
+            raise SystemExit(f"missing doc token: {token}")
+
+    print("GRF full-solve certificate gate verification OK.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_grf_full_solve_certificate_gate.py
+++ b/tests/test_grf_full_solve_certificate_gate.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import json
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_grf_full_solve_certificate_gate_verifier_passes():
+    result = subprocess.run(
+        [sys.executable, "scripts/verify_grf_full_solve_certificate_gate.py"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert "verification OK" in result.stdout
+
+
+def test_grf_full_solve_certificate_gate_has_all_eight_obligations():
+    artifact = json.loads(
+        (ROOT / "artifacts/grf/full_solve_certificate_gate.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    obligations = {item["id"]: item for item in artifact["required_obligations"]}
+    assert len(obligations) == 8
+    assert "O1_POSITIVE_INNER_BOUNDARY_MARGIN" in obligations
+    assert "O2_ACTUAL_DERIVATIVE_DATA" in obligations
+    assert "O3_FIRST_CELL_NUMERIC_CERTIFICATE" in obligations
+    assert "O4_MULTI_CELL_PROPAGATION" in obligations
+    assert "O5_ALL_WEC_DEC_COMPONENTS" in obligations
+    assert "O6_MATCHING_THEOREM" in obligations
+    assert "O7_PHYSICAL_REALIZATION" in obligations
+    assert "O8_FORMAL_VERIFICATION" in obligations
+    assert all(item["status"].startswith("MISSING_") for item in obligations.values())
+    assert artifact["status"] == "FRONTIER_OPEN_FULL_CERTIFICATE_GATE"
+    assert any("not GRF theorem-level closure" in item for item in artifact["boundary"])


### PR DESCRIPTION
Adds the full-solve certificate gate for the GRF transition-shell frontier.

Change:
- Enumerates the eight required obligations for theorem-level transition-shell closure.
- Records the missing status of positive boundary margin, derivative data, first-cell numeric certificate, multi-cell propagation, WEC/DEC component certificates, matching theorem, physical realization, and final executable verification.
- Adds a JSON artifact, essay/status doc, verifier, and regression tests.
- Enforces that theorem-level closure remains forbidden until all obligations are supplied and verified.

Boundary:
- Certificate gate only.
- Not a positive inner-boundary margin proof.
- Not derivative data construction.
- Not a first-cell numeric certificate.
- Not a multi-cell interval certificate.
- Not WEC/DEC closure.
- Not a matching theorem.
- Not a physical realization theorem.
- Not GRF theorem-level closure.

Verification:
- python3 scripts/verify_grf_full_solve_certificate_gate.py
- python3 -m pytest -q tests/test_grf_full_solve_certificate_gate.py