### PR TITLE
docs(essay): add positive inner-boundary margin certificate

### DIFF
--- a/artifacts/grf/positive_inner_boundary_margin_certificate.json
+++ b/artifacts/grf/positive_inner_boundary_margin_certificate.json
@@ -1,0 +1,28 @@
+{
+  "id": "GRF_2026_POSITIVE_INNER_BOUNDARY_MARGIN_CERTIFICATE",
+  "title": "Positive inner-boundary margin certificate for rho_minus_pt",
+  "status": "FRONTIER_OPEN_MARGIN_CERTIFICATE_INTERFACE",
+  "obligation": "O1_POSITIVE_INNER_BOUNDARY_MARGIN",
+  "required_object": "rho_minus_pt(r1) >= eta > 0",
+  "certificate_input_path": "artifacts/grf/positive_inner_boundary_margin_input.json",
+  "verification_rule": "Given numeric rho_minus_pt_r1 and eta, O1 is verified only if eta > 0 and rho_minus_pt_r1 >= eta.",
+  "feeds": [
+    "GRF_2026_FIRST_CELL_POSITIVITY_CERTIFICATE",
+    "GRF_2026_FULL_SOLVE_CERTIFICATE_GATE"
+  ],
+  "boundary": [
+    "certificate interface only",
+    "not a proof that eta exists",
+    "not a computation of rho_minus_pt(r1)",
+    "not a first-cell positivity certificate",
+    "not a multi-cell interval certificate",
+    "not WEC/DEC closure",
+    "not a matching theorem",
+    "not a physical realization theorem",
+    "not GRF theorem-level closure"
+  ],
+  "verification": [
+    "python3 scripts/verify_grf_positive_inner_boundary_margin_certificate.py",
+    "python3 -m pytest -q tests/test_grf_positive_inner_boundary_margin_certificate.py"
+  ]
+}

--- a/docs/essays/GRF_2026_POSITIVE_INNER_BOUNDARY_MARGIN_CERTIFICATE.md
+++ b/docs/essays/GRF_2026_POSITIVE_INNER_BOUNDARY_MARGIN_CERTIFICATE.md
@@ -1,0 +1,100 @@
+# GRF Positive Inner-Boundary Margin Certificate
+
+Status: `FRONTIER_OPEN_MARGIN_CERTIFICATE_INTERFACE`
+
+## Obligation
+
+This document isolates the first full-solve obligation:
+
+\[
+O1:\qquad \rho(r_1)-p_t(r_1)\ge \eta>0.
+\]
+
+Let
+
+\[
+f(r)=\rho(r)-p_t(r).
+\]
+
+The required object is
+
+\[
+f(r_1)\ge \eta>0.
+\]
+
+## Executable certificate rule
+
+A numeric O1 certificate must provide:
+
+\[
+f(r_1),
+\qquad
+\eta.
+\]
+
+The certificate verifies only when
+
+\[
+\eta>0
+\]
+
+and
+
+\[
+f(r_1)-\eta\ge0.
+\]
+
+Equivalently,
+
+\[
+f(r_1)\ge\eta>0.
+\]
+
+## Expected input
+
+The expected executable certificate input path is
+
+\[
+\texttt{artifacts/grf/positive\_inner\_boundary\_margin\_input.json}.
+\]
+
+The required input fields are:
+
+```json
+{
+  "certificate_id": "O1_POSITIVE_INNER_BOUNDARY_MARGIN",
+  "status": "VERIFIED",
+  "rho_minus_pt_r1": 0.0,
+  "eta": 0.0
+}
+The values above are placeholders only. A valid certificate requires concrete values with
+η>0
+and
+ρ_minus_pt_r1≥η.
+Interface result
+If the executable input exists and passes the checker, then O1 is certified:
+PositiveInnerBoundaryMargin(r 
+1
+​	
+ ,η).
+This feeds the first-cell positivity certificate and the full-solve certificate gate.
+Boundary
+This is a certificate interface only.
+It does not prove:
+that η exists,
+a computation of ρ(r 
+1
+​	
+ )−p 
+t
+​	
+ (r 
+1
+​	
+ ),
+a first-cell positivity certificate,
+a multi-cell interval certificate,
+WEC/DEC closure,
+a matching theorem,
+a physical realization theorem,
+GRF theorem-level closure.

--- a/scripts/verify_grf_positive_inner_boundary_margin_certificate.py
+++ b/scripts/verify_grf_positive_inner_boundary_margin_certificate.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from numbers import Real
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ART = ROOT / "artifacts/grf/positive_inner_boundary_margin_certificate.json"
+DOC = ROOT / "docs/essays/GRF_2026_POSITIVE_INNER_BOUNDARY_MARGIN_CERTIFICATE.md"
+INPUT = ROOT / "artifacts/grf/positive_inner_boundary_margin_input.json"
+
+REQUIRED_DOC_TOKENS = [
+    "Status: `FRONTIER_OPEN_MARGIN_CERTIFICATE_INTERFACE`",
+    "O1:\\qquad \\rho(r_1)-p_t(r_1)\\ge \\eta>0",
+    "f(r)=\\rho(r)-p_t(r)",
+    "f(r_1)\\ge \\eta>0",
+    "f(r_1)-\\eta\\ge0",
+    "artifacts/grf/positive\\_inner\\_boundary\\_margin\\_input.json",
+    "PositiveInnerBoundaryMargin",
+    "It does not prove:",
+    "GRF theorem-level closure",
+]
+
+REQUIRED_BOUNDARY_TOKENS = [
+    "certificate interface only",
+    "not a proof that eta exists",
+    "not a computation of rho_minus_pt(r1)",
+    "not a first-cell positivity certificate",
+    "not a multi-cell interval certificate",
+    "not WEC/DEC closure",
+    "not a matching theorem",
+    "not a physical realization theorem",
+    "not GRF theorem-level closure",
+]
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+
+def validate_optional_input() -> None:
+    if not INPUT.exists():
+        return
+
+    data = json.loads(INPUT.read_text(encoding="utf-8"))
+
+    require(
+        data.get("certificate_id") == "O1_POSITIVE_INNER_BOUNDARY_MARGIN",
+        "input certificate_id must be O1_POSITIVE_INNER_BOUNDARY_MARGIN",
+    )
+    require(data.get("status") == "VERIFIED", "input status must be VERIFIED")
+
+    eta = data.get("eta")
+    rho_minus_pt_r1 = data.get("rho_minus_pt_r1")
+
+    require(isinstance(eta, Real), "eta must be numeric")
+    require(isinstance(rho_minus_pt_r1, Real), "rho_minus_pt_r1 must be numeric")
+    require(eta > 0, "eta must be positive")
+    require(rho_minus_pt_r1 >= eta, "rho_minus_pt_r1 must be >= eta")
+
+
+def main() -> None:
+    require(ART.exists(), f"missing artifact: {ART}")
+    require(DOC.exists(), f"missing doc: {DOC}")
+
+    artifact = json.loads(ART.read_text(encoding="utf-8"))
+
+    require(
+        artifact.get("id") == "GRF_2026_POSITIVE_INNER_BOUNDARY_MARGIN_CERTIFICATE",
+        "bad artifact id",
+    )
+    require(
+        artifact.get("status") == "FRONTIER_OPEN_MARGIN_CERTIFICATE_INTERFACE",
+        "artifact must remain an open certificate interface",
+    )
+    require(
+        artifact.get("obligation") == "O1_POSITIVE_INNER_BOUNDARY_MARGIN",
+        "bad obligation id",
+    )
+    require(
+        artifact.get("required_object") == "rho_minus_pt(r1) >= eta > 0",
+        "bad required object",
+    )
+    require(
+        artifact.get("certificate_input_path")
+        == "artifacts/grf/positive_inner_boundary_margin_input.json",
+        "bad certificate input path",
+    )
+
+    boundary = "\n".join(artifact.get("boundary", []))
+    for token in REQUIRED_BOUNDARY_TOKENS:
+        require(token in boundary, f"missing boundary token: {token}")
+
+    doc = DOC.read_text(encoding="utf-8")
+    for token in REQUIRED_DOC_TOKENS:
+        require(token in doc, f"missing doc token: {token}")
+
+    validate_optional_input()
+
+    print("GRF positive inner-boundary margin certificate interface verification OK.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_grf_positive_inner_boundary_margin_certificate.py
+++ b/tests/test_grf_positive_inner_boundary_margin_certificate.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+import json
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_positive_inner_boundary_margin_certificate_verifier_passes():
+    result = subprocess.run(
+        [sys.executable, "scripts/verify_grf_positive_inner_boundary_margin_certificate.py"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert "verification OK" in result.stdout
+
+
+def test_positive_inner_boundary_margin_artifact_is_open_interface():
+    artifact = json.loads(
+        (ROOT / "artifacts/grf/positive_inner_boundary_margin_certificate.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert artifact["status"] == "FRONTIER_OPEN_MARGIN_CERTIFICATE_INTERFACE"
+    assert artifact["obligation"] == "O1_POSITIVE_INNER_BOUNDARY_MARGIN"
+    assert artifact["required_object"] == "rho_minus_pt(r1) >= eta > 0"
+    assert artifact["certificate_input_path"] == (
+        "artifacts/grf/positive_inner_boundary_margin_input.json"
+    )
+    assert "GRF_2026_FULL_SOLVE_CERTIFICATE_GATE" in artifact["feeds"]
+    assert any("not GRF theorem-level closure" in item for item in artifact["boundary"])
+
+
+def test_positive_inner_boundary_margin_optional_input_validation_accepts_valid_data():
+    script = ROOT / "scripts/verify_grf_positive_inner_boundary_margin_certificate.py"
+    input_path = ROOT / "artifacts/grf/positive_inner_boundary_margin_input.json"
+    try:
+        input_path.write_text(
+            json.dumps(
+                {
+                    "certificate_id": "O1_POSITIVE_INNER_BOUNDARY_MARGIN",
+                    "status": "VERIFIED",
+                    "rho_minus_pt_r1": 2.0,
+                    "eta": 1.0,
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        assert "verification OK" in result.stdout
+    finally:
+        input_path.unlink(missing_ok=True)


### PR DESCRIPTION
Adds the executable O1 positive inner-boundary margin certificate interface for the GRF transition-shell frontier.

Verification:
- python3 scripts/verify_grf_positive_inner_boundary_margin_certificate.py
- python3 -m pytest -q tests/test_grf_positive_inner_boundary_margin_certificate.py