### PR TITLE
docs(essay): add positive inner-boundary margin closure targets

### DIFF
--- a/artifacts/grf/positive_inner_boundary_margin_closure_targets.json
+++ b/artifacts/grf/positive_inner_boundary_margin_closure_targets.json
@@ -1,0 +1,66 @@
+{
+  "artifact": "GRF_POSITIVE_INNER_BOUNDARY_MARGIN_CLOSURE_TARGETS",
+  "status": "FRONTIER_OPEN",
+  "source_interface": "positive_inner_boundary_margin_certificate.json",
+  "targets": [
+    {
+      "name": "EtaExistence",
+      "statement": "There exists eta > 0 such that rho_minus_pt(r1) >= eta.",
+      "status": "OPEN",
+      "minimal_missing_object": "analytic_eta_existence_proof"
+    },
+    {
+      "name": "RhoMinusPtBoundaryComputation",
+      "statement": "The expression rho_minus_pt(r1) is computed from the GRF transition-shell data.",
+      "status": "OPEN",
+      "minimal_missing_object": "symbolic_or_numeric_rho_minus_pt_r1_computation"
+    },
+    {
+      "name": "FirstCellPositivityCertificate",
+      "statement": "rho_minus_pt is positive on the first radial cell adjacent to r1.",
+      "status": "OPEN",
+      "minimal_missing_object": "first_cell_interval_lower_bound"
+    },
+    {
+      "name": "MultiCellIntervalCertificate",
+      "statement": "rho_minus_pt satisfies the required lower-bound inequality on all declared transition-shell cells.",
+      "status": "OPEN",
+      "minimal_missing_object": "multi_cell_interval_certificate"
+    },
+    {
+      "name": "WECDECClosure",
+      "statement": "The declared GRF matter profile satisfies the required WEC/DEC inequalities on the certified domain.",
+      "status": "OPEN",
+      "minimal_missing_object": "wec_dec_interval_certificate"
+    },
+    {
+      "name": "MatchingTheorem",
+      "statement": "The inner-boundary margin certificate is compatible with the matching conditions.",
+      "status": "OPEN",
+      "minimal_missing_object": "matching_condition_certificate"
+    },
+    {
+      "name": "PhysicalRealizationTheorem",
+      "statement": "The certified profile is physically realized by admissible GRF data.",
+      "status": "OPEN",
+      "minimal_missing_object": "physical_realization_certificate"
+    },
+    {
+      "name": "GRFTheoremLevelClosure",
+      "statement": "Eta existence, boundary computation, interval positivity, energy-condition closure, matching, and physical realization jointly imply GRF theorem-level closure for this margin target.",
+      "status": "CONDITIONAL",
+      "minimal_missing_object": "all_prior_targets_closed"
+    }
+  ],
+  "conditional_closure_rule": "GRFTheoremLevelClosure follows only after all seven predecessor targets are closed.",
+  "does_not_prove": [
+    "eta exists",
+    "rho_minus_pt(r1) has been computed",
+    "first-cell positivity",
+    "multi-cell interval positivity",
+    "WEC/DEC closure",
+    "matching theorem",
+    "physical realization theorem",
+    "GRF theorem-level closure"
+  ]
+}

--- a/docs/essays/GRF_2026_POSITIVE_INNER_BOUNDARY_MARGIN_CLOSURE_TARGETS.md
+++ b/docs/essays/GRF_2026_POSITIVE_INNER_BOUNDARY_MARGIN_CLOSURE_TARGETS.md
@@ -1,0 +1,33 @@
+# GRF Positive Inner-Boundary Margin Closure Targets
+
+Status: `FRONTIER_OPEN`
+
+This document converts the prior certificate-interface boundary into explicit closure targets.
+
+## Targets
+
+1. `EtaExistence`
+2. `RhoMinusPtBoundaryComputation`
+3. `FirstCellPositivityCertificate`
+4. `MultiCellIntervalCertificate`
+5. `WECDECClosure`
+6. `MatchingTheorem`
+7. `PhysicalRealizationTheorem`
+8. `GRFTheoremLevelClosure`
+
+## Conditional closure rule
+
+`GRFTheoremLevelClosure` follows only after all seven predecessor targets are closed.
+
+## Boundary
+
+Does not prove:
+
+- eta exists
+- rho_minus_pt(r1) has been computed
+- first-cell positivity
+- multi-cell interval positivity
+- WEC/DEC closure
+- matching theorem
+- physical realization theorem
+- GRF theorem-level closure

--- a/scripts/verify_grf_positive_inner_boundary_margin_closure_targets.py
+++ b/scripts/verify_grf_positive_inner_boundary_margin_closure_targets.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT = ROOT / "artifacts/grf/positive_inner_boundary_margin_closure_targets.json"
+DOC = ROOT / "docs/essays/GRF_2026_POSITIVE_INNER_BOUNDARY_MARGIN_CLOSURE_TARGETS.md"
+
+REQUIRED_TARGETS = [
+    "EtaExistence",
+    "RhoMinusPtBoundaryComputation",
+    "FirstCellPositivityCertificate",
+    "MultiCellIntervalCertificate",
+    "WECDECClosure",
+    "MatchingTheorem",
+    "PhysicalRealizationTheorem",
+    "GRFTheoremLevelClosure",
+]
+
+REQUIRED_BOUNDARY = [
+    "eta exists",
+    "rho_minus_pt(r1) has been computed",
+    "first-cell positivity",
+    "multi-cell interval positivity",
+    "WEC/DEC closure",
+    "matching theorem",
+    "physical realization theorem",
+    "GRF theorem-level closure",
+]
+
+data = json.loads(ARTIFACT.read_text())
+doc = DOC.read_text()
+
+assert data["status"] == "FRONTIER_OPEN"
+assert [target["name"] for target in data["targets"]] == REQUIRED_TARGETS
+assert data["targets"][-1]["status"] == "CONDITIONAL"
+assert data["targets"][-1]["minimal_missing_object"] == "all_prior_targets_closed"
+
+for target in data["targets"][:-1]:
+    assert target["status"] == "OPEN"
+    assert target["minimal_missing_object"]
+
+for token in REQUIRED_BOUNDARY:
+    assert token in data["does_not_prove"]
+    assert token in doc
+
+assert "`GRFTheoremLevelClosure` follows only after all seven predecessor targets are closed." in doc
+
+print("GRF positive inner-boundary margin closure targets verified.")

--- a/tests/test_grf_positive_inner_boundary_margin_closure_targets.py
+++ b/tests/test_grf_positive_inner_boundary_margin_closure_targets.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT = ROOT / "artifacts/grf/positive_inner_boundary_margin_closure_targets.json"
+
+def test_targets_exist() -> None:
+    data = json.loads(ARTIFACT.read_text())
+    assert [target["name"] for target in data["targets"]] == [
+        "EtaExistence",
+        "RhoMinusPtBoundaryComputation",
+        "FirstCellPositivityCertificate",
+        "MultiCellIntervalCertificate",
+        "WECDECClosure",
+        "MatchingTheorem",
+        "PhysicalRealizationTheorem",
+        "GRFTheoremLevelClosure",
+    ]
+
+def test_all_real_targets_remain_open() -> None:
+    data = json.loads(ARTIFACT.read_text())
+    assert all(target["status"] == "OPEN" for target in data["targets"][:-1])
+    assert data["targets"][-1]["status"] == "CONDITIONAL"
+
+def test_boundary_preserved() -> None:
+    data = json.loads(ARTIFACT.read_text())
+    assert "GRF theorem-level closure" in data["does_not_prove"]
+    assert "eta exists" in data["does_not_prove"]
+
+def test_verifier_passes() -> None:
+    subprocess.run(
+        [sys.executable, "scripts/verify_grf_positive_inner_boundary_margin_closure_targets.py"],
+        cwd=ROOT,
+        check=True,
+    )


### PR DESCRIPTION
Adds explicit closure targets for the GRF positive inner-boundary margin route.

Targets:
- `EtaExistence`
- `RhoMinusPtBoundaryComputation`
- `FirstCellPositivityCertificate`
- `MultiCellIntervalCertificate`
- `WECDECClosure`
- `MatchingTheorem`
- `PhysicalRealizationTheorem`
- `GRFTheoremLevelClosure`

Status:
`FRONTIER_OPEN`

Boundary:
Does not prove eta exists, rho_minus_pt(r1) has been computed, first-cell positivity, multi-cell interval positivity, WEC/DEC closure, matching theorem, physical realization theorem, or GRF theorem-level closure.

Verification:
- python3 scripts/verify_grf_positive_inner_boundary_margin_closure_targets.py
- python3 -m pytest -q tests/test_grf_positive_inner_boundary_margin_closure_targets.py
- git diff --check
