### PR TITLE
docs(essay): add GRF transition-shell certificate schema pack

### DIFF
--- a/artifacts/grf/complete_transition_shell_certificate_schema.json
+++ b/artifacts/grf/complete_transition_shell_certificate_schema.json
@@ -1,0 +1,29 @@
+{
+  "id": "GRF_2026_COMPLETE_TRANSITION_SHELL_CERTIFICATE_SCHEMA",
+  "title": "Complete GRF transition-shell certificate schema",
+  "status": "FRONTIER_OPEN_SCHEMA_ONLY",
+  "schema_name": "CompleteGRFTransitionShellCertificate",
+  "required_gates": [
+    "O1_POSITIVE_INNER_BOUNDARY_MARGIN",
+    "O2_ACTUAL_DERIVATIVE_DATA",
+    "O3_FIRST_CELL_NUMERIC_CERTIFICATE",
+    "O4_MULTI_CELL_INTERVAL_PROPAGATION",
+    "O5_WEC_DEC_COMPONENT_INVENTORY",
+    "O6_MATCHING_THEOREM",
+    "O7_PHYSICAL_REALIZATION_THEOREM",
+    "O8_FINAL_EXECUTABLE_VERIFICATION"
+  ],
+  "closure_rule": "GRF theorem-level closure is forbidden unless every required gate is VERIFIED by executable certificate data.",
+  "boundary": [
+    "schema only",
+    "not eta existence",
+    "not rho_minus_pt(r1) computation",
+    "not derivative data construction",
+    "not a first-cell numeric certificate",
+    "not a multi-cell interval certificate",
+    "not WEC/DEC closure",
+    "not a matching theorem",
+    "not a physical realization theorem",
+    "not GRF theorem-level closure"
+  ]
+}

--- a/artifacts/grf/matching_realization_theorem_gate.json
+++ b/artifacts/grf/matching_realization_theorem_gate.json
@@ -1,0 +1,25 @@
+{
+  "id": "GRF_2026_MATCHING_REALIZATION_THEOREM_GATE",
+  "title": "Matching and physical-realization theorem gate",
+  "status": "FRONTIER_OPEN_MATCHING_REALIZATION_GATE",
+  "obligations": [
+    "O6_MATCHING_THEOREM",
+    "O7_PHYSICAL_REALIZATION_THEOREM"
+  ],
+  "required_objects": [
+    "inner-shell-outer matching with required regularity",
+    "admissible geometry/matter realization for chosen m(r), Phi(r), shell width, and parameters"
+  ],
+  "certificate_input_path": "artifacts/grf/matching_realization_theorem_input.json",
+  "verification_rule": "O6/O7 are verified only if matching regularity and physical admissibility certificates are both present and marked VERIFIED.",
+  "feeds": [
+    "GRF_2026_COMPLETE_TRANSITION_SHELL_CERTIFICATE_SCHEMA"
+  ],
+  "boundary": [
+    "gate only",
+    "not a matching theorem",
+    "not a physical realization theorem",
+    "not WEC/DEC closure",
+    "not GRF theorem-level closure"
+  ]
+}

--- a/artifacts/grf/multi_cell_interval_certificate_interface.json
+++ b/artifacts/grf/multi_cell_interval_certificate_interface.json
@@ -1,0 +1,31 @@
+{
+  "id": "GRF_2026_MULTI_CELL_INTERVAL_CERTIFICATE_INTERFACE",
+  "title": "Multi-cell interval propagation certificate interface",
+  "status": "FRONTIER_OPEN_MULTI_CELL_INTERFACE",
+  "obligation": "O4_MULTI_CELL_INTERVAL_PROPAGATION",
+  "required_object": "finite interval cover of the full shell with per-cell eta_j - L_j*dr_j >= 0",
+  "certificate_input_path": "artifacts/grf/multi_cell_interval_certificate_input.json",
+  "required_fields": [
+    "shell_left",
+    "shell_right",
+    "cells",
+    "cell.left",
+    "cell.right",
+    "cell.eta",
+    "cell.L"
+  ],
+  "verification_rule": "O4 is verified only if cells form a contiguous cover of [shell_left,shell_right], every cell has positive width, eta_j >= 0, L_j >= 0, and eta_j - L_j*(right-left) >= 0.",
+  "feeds": [
+    "GRF_2026_COMPLETE_TRANSITION_SHELL_CERTIFICATE_SCHEMA"
+  ],
+  "boundary": [
+    "certificate interface only",
+    "not construction of the interval cover",
+    "not proof of per-cell derivative data",
+    "not all WEC/DEC component closure",
+    "not WEC/DEC closure",
+    "not a matching theorem",
+    "not a physical realization theorem",
+    "not GRF theorem-level closure"
+  ]
+}

--- a/artifacts/grf/o2_derivative_data_certificate_interface.json
+++ b/artifacts/grf/o2_derivative_data_certificate_interface.json
@@ -1,0 +1,34 @@
+{
+  "id": "GRF_2026_O2_DERIVATIVE_DATA_CERTIFICATE_INTERFACE",
+  "title": "O2 derivative-data certificate interface",
+  "status": "FRONTIER_OPEN_DERIVATIVE_DATA_INTERFACE",
+  "obligation": "O2_ACTUAL_DERIVATIVE_DATA",
+  "required_object": "bounds on m, m', m'', Phi', Phi'', Phi''' producing concrete L_cell",
+  "certificate_input_path": "artifacts/grf/o2_derivative_data_input.json",
+  "required_fields": [
+    "r0",
+    "a",
+    "M0",
+    "M1",
+    "M2",
+    "P1",
+    "P2",
+    "P3",
+    "L_cell"
+  ],
+  "verification_rule": "O2 is verified only if all bounds are numeric, r0 > 0, a > 0, all absolute-value bounds are nonnegative, L_cell >= 0, and the recomputed L_cell upper bound is <= supplied L_cell.",
+  "feeds": [
+    "GRF_2026_FIRST_CELL_DERIVATIVE_MODULUS_BOUND",
+    "GRF_2026_COMPLETE_TRANSITION_SHELL_CERTIFICATE_SCHEMA"
+  ],
+  "boundary": [
+    "certificate interface only",
+    "not derivative data construction",
+    "not proof the chosen functions satisfy the bounds",
+    "not a first-cell numeric certificate",
+    "not WEC/DEC closure",
+    "not a matching theorem",
+    "not a physical realization theorem",
+    "not GRF theorem-level closure"
+  ]
+}

--- a/artifacts/grf/wec_dec_component_inventory_gate.json
+++ b/artifacts/grf/wec_dec_component_inventory_gate.json
@@ -1,0 +1,27 @@
+{
+  "id": "GRF_2026_WEC_DEC_COMPONENT_INVENTORY_GATE",
+  "title": "WEC/DEC component inventory gate",
+  "status": "FRONTIER_OPEN_COMPONENT_GATE",
+  "obligation": "O5_WEC_DEC_COMPONENT_INVENTORY",
+  "required_components": [
+    "rho >= 0",
+    "rho + p_r >= 0",
+    "rho + p_t >= 0",
+    "rho - |p_r| >= 0",
+    "rho - |p_t| >= 0",
+    "rho - p_t >= 0"
+  ],
+  "certificate_input_path": "artifacts/grf/wec_dec_component_inventory_input.json",
+  "verification_rule": "O5 is verified only if every listed component has a verified interval certificate on the whole shell.",
+  "feeds": [
+    "GRF_2026_COMPLETE_TRANSITION_SHELL_CERTIFICATE_SCHEMA"
+  ],
+  "boundary": [
+    "component inventory gate only",
+    "not WEC/DEC closure",
+    "not proof of any component inequality",
+    "not a matching theorem",
+    "not a physical realization theorem",
+    "not GRF theorem-level closure"
+  ]
+}

--- a/docs/essays/GRF_2026_TRANSITION_SHELL_CERTIFICATE_SCHEMA_PACK.md
+++ b/docs/essays/GRF_2026_TRANSITION_SHELL_CERTIFICATE_SCHEMA_PACK.md
@@ -1,0 +1,104 @@
+# GRF Transition-Shell Certificate Schema Pack
+
+Status: `FRONTIER_OPEN_SCHEMA_PACK`
+
+## Added objects
+
+This pack adds the following frontier interfaces:
+
+1. `CompleteGRFTransitionShellCertificate`
+2. `O2_ACTUAL_DERIVATIVE_DATA`
+3. `O4_MULTI_CELL_INTERVAL_PROPAGATION`
+4. `O5_WEC_DEC_COMPONENT_INVENTORY`
+5. `O6_MATCHING_THEOREM` / `O7_PHYSICAL_REALIZATION_THEOREM`
+
+## Complete schema
+
+A complete certificate requires:
+
+\[
+\mathrm{CompleteGRFTransitionShellCertificate}.
+\]
+
+The required gates are:
+
+\[
+O1,\ O2,\ O3,\ O4,\ O5,\ O6,\ O7,\ O8.
+\]
+
+GRF theorem-level closure is forbidden unless every required gate is `VERIFIED` by executable certificate data.
+
+## O2 derivative-data interface
+
+Required object:
+
+\[
+|m|\le M_0,\quad |m'|\le M_1,\quad |m''|\le M_2,
+\]
+
+\[
+|\Phi'|\le P_1,\quad |\Phi''|\le P_2,\quad |\Phi'''|\le P_3.
+\]
+
+These must produce a concrete \(L_{\rm cell}\).
+
+## O4 multi-cell interval interface
+
+Required object:
+
+\[
+\forall j,\qquad \eta_j-L_j\Delta r_j\ge0.
+\]
+
+The cells must form a contiguous cover of the full transition shell.
+
+## O5 WEC/DEC component inventory gate
+
+Required components include:
+
+\[
+\rho\ge0,
+\qquad
+\rho+p_r\ge0,
+\qquad
+\rho+p_t\ge0,
+\]
+
+\[
+\rho-|p_r|\ge0,
+\qquad
+\rho-|p_t|\ge0,
+\qquad
+\rho-p_t\ge0.
+\]
+
+Every listed component must have a verified interval certificate on the whole shell.
+
+## O6/O7 matching-realization gate
+
+Required objects:
+
+\[
+\text{inner-shell-outer matching with required regularity}
+\]
+
+and
+
+\[
+\text{admissible physical realization for the chosen shell data}.
+\]
+
+## Boundary
+
+This is a schema/interface pack only.
+
+It does not prove:
+- eta existence,
+- computation of \(\rho(r_1)-p_t(r_1)\),
+- derivative data construction,
+- a first-cell numeric certificate,
+- a multi-cell interval certificate,
+- WEC/DEC closure,
+- a matching theorem,
+- a physical realization theorem,
+- GRF theorem-level closure.

--- a/scripts/verify_grf_transition_shell_certificate_schema_pack.py
+++ b/scripts/verify_grf_transition_shell_certificate_schema_pack.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+FILES = {
+    "complete": ROOT / "artifacts/grf/complete_transition_shell_certificate_schema.json",
+    "o2": ROOT / "artifacts/grf/o2_derivative_data_certificate_interface.json",
+    "multi": ROOT / "artifacts/grf/multi_cell_interval_certificate_interface.json",
+    "wec_dec": ROOT / "artifacts/grf/wec_dec_component_inventory_gate.json",
+    "matching": ROOT / "artifacts/grf/matching_realization_theorem_gate.json",
+    "doc": ROOT / "docs/essays/GRF_2026_TRANSITION_SHELL_CERTIFICATE_SCHEMA_PACK.md",
+}
+
+REQUIRED_STATUSES = {
+    "complete": "FRONTIER_OPEN_SCHEMA_ONLY",
+    "o2": "FRONTIER_OPEN_DERIVATIVE_DATA_INTERFACE",
+    "multi": "FRONTIER_OPEN_MULTI_CELL_INTERFACE",
+    "wec_dec": "FRONTIER_OPEN_COMPONENT_GATE",
+    "matching": "FRONTIER_OPEN_MATCHING_REALIZATION_GATE",
+}
+
+REQUIRED_GATES = {
+    "O1_POSITIVE_INNER_BOUNDARY_MARGIN",
+    "O2_ACTUAL_DERIVATIVE_DATA",
+    "O3_FIRST_CELL_NUMERIC_CERTIFICATE",
+    "O4_MULTI_CELL_INTERVAL_PROPAGATION",
+    "O5_WEC_DEC_COMPONENT_INVENTORY",
+    "O6_MATCHING_THEOREM",
+    "O7_PHYSICAL_REALIZATION_THEOREM",
+    "O8_FINAL_EXECUTABLE_VERIFICATION",
+}
+
+REQUIRED_DOC_TOKENS = [
+    "Status: `FRONTIER_OPEN_SCHEMA_PACK`",
+    "CompleteGRFTransitionShellCertificate",
+    "O2_ACTUAL_DERIVATIVE_DATA",
+    "O4_MULTI_CELL_INTERVAL_PROPAGATION",
+    "O5_WEC_DEC_COMPONENT_INVENTORY",
+    "O6_MATCHING_THEOREM",
+    "O7_PHYSICAL_REALIZATION_THEOREM",
+    "GRF theorem-level closure is forbidden",
+    "It does not prove:",
+    "GRF theorem-level closure",
+]
+
+REQUIRED_BOUNDARY_TOKENS = [
+    "not WEC/DEC closure",
+    "not a matching theorem",
+    "not a physical realization theorem",
+    "not GRF theorem-level closure",
+]
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+
+def load_json(name: str) -> dict:
+    path = FILES[name]
+    require(path.exists(), f"missing file: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> None:
+    for path in FILES.values():
+        require(path.exists(), f"missing file: {path}")
+
+    complete = load_json("complete")
+    require(
+        complete.get("schema_name") == "CompleteGRFTransitionShellCertificate",
+        "missing complete schema name",
+    )
+    require(set(complete.get("required_gates", [])) == REQUIRED_GATES, "bad required gate set")
+
+    for name, status in REQUIRED_STATUSES.items():
+        data = load_json(name)
+        require(data.get("status") == status, f"bad status for {name}")
+        boundary = "\n".join(data.get("boundary", []))
+        for token in REQUIRED_BOUNDARY_TOKENS:
+            require(token in boundary, f"missing boundary token in {name}: {token}")
+
+    o2 = load_json("o2")
+    for field in ["r0", "a", "M0", "M1", "M2", "P1", "P2", "P3", "L_cell"]:
+        require(field in o2.get("required_fields", []), f"missing O2 required field: {field}")
+
+    multi = load_json("multi")
+    require("cell.eta" in multi.get("required_fields", []), "missing multi-cell eta field")
+    require("cell.L" in multi.get("required_fields", []), "missing multi-cell L field")
+
+    wec_dec = load_json("wec_dec")
+    for component in ["rho >= 0", "rho + p_r >= 0", "rho + p_t >= 0", "rho - |p_r| >= 0", "rho - |p_t| >= 0", "rho - p_t >= 0"]:
+        require(component in wec_dec.get("required_components", []), f"missing WEC/DEC component: {component}")
+
+    matching = load_json("matching")
+    require("O6_MATCHING_THEOREM" in matching.get("obligations", []), "missing O6")
+    require("O7_PHYSICAL_REALIZATION_THEOREM" in matching.get("obligations", []), "missing O7")
+
+    doc = FILES["doc"].read_text(encoding="utf-8")
+    for token in REQUIRED_DOC_TOKENS:
+        require(token in doc, f"missing doc token: {token}")
+
+    print("GRF transition-shell certificate schema pack verification OK.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_grf_transition_shell_certificate_schema_pack.py
+++ b/tests/test_grf_transition_shell_certificate_schema_pack.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+import json
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_grf_transition_shell_certificate_schema_pack_verifier_passes():
+    result = subprocess.run(
+        [sys.executable, "scripts/verify_grf_transition_shell_certificate_schema_pack.py"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert "verification OK" in result.stdout
+
+
+def test_complete_grf_transition_shell_certificate_schema_has_all_gates():
+    artifact = json.loads(
+        (ROOT / "artifacts/grf/complete_transition_shell_certificate_schema.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    gates = set(artifact["required_gates"])
+    assert artifact["schema_name"] == "CompleteGRFTransitionShellCertificate"
+    assert artifact["status"] == "FRONTIER_OPEN_SCHEMA_ONLY"
+    assert "O2_ACTUAL_DERIVATIVE_DATA" in gates
+    assert "O4_MULTI_CELL_INTERVAL_PROPAGATION" in gates
+    assert "O5_WEC_DEC_COMPONENT_INVENTORY" in gates
+    assert "O6_MATCHING_THEOREM" in gates
+    assert "O7_PHYSICAL_REALIZATION_THEOREM" in gates
+    assert any("not GRF theorem-level closure" in item for item in artifact["boundary"])
+
+
+def test_component_and_matching_gates_are_open():
+    wec_dec = json.loads(
+        (ROOT / "artifacts/grf/wec_dec_component_inventory_gate.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    matching = json.loads(
+        (ROOT / "artifacts/grf/matching_realization_theorem_gate.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert wec_dec["status"] == "FRONTIER_OPEN_COMPONENT_GATE"
+    assert matching["status"] == "FRONTIER_OPEN_MATCHING_REALIZATION_GATE"
+    assert "rho - p_t >= 0" in wec_dec["required_components"]
+    assert "O6_MATCHING_THEOREM" in matching["obligations"]
+    assert "O7_PHYSICAL_REALIZATION_THEOREM" in matching["obligations"]


### PR DESCRIPTION
Adds the next GRF transition-shell certificate schema pack.

Change:
- Adds CompleteGRFTransitionShellCertificate schema.
- Adds O2 derivative-data certificate interface.
- Adds multi-cell interval certificate interface.
- Adds WEC/DEC component inventory gate.
- Adds matching/realization theorem gate.
- Adds a verifier and regression tests.

Boundary:
- Schema/interface pack only.
- Not eta existence.
- Not rho_minus_pt(r1) computation.
- Not derivative data construction.
- Not a first-cell numeric certificate.
- Not a multi-cell interval certificate.
- Not WEC/DEC closure.
- Not a matching theorem.
- Not a physical realization theorem.
- Not GRF theorem-level closure.

Verification:
- python3 scripts/verify_grf_transition_shell_certificate_schema_pack.py
- python3 -m pytest -q tests/test_grf_transition_shell_certificate_schema_pack.py