### PR TITLE
docs(essay): add GRF eta existence target

### DIFF
--- a/artifacts/grf/eta_existence_target.json
+++ b/artifacts/grf/eta_existence_target.json
@@ -1,0 +1,22 @@
+{
+  "artifact": "GRF_ETA_EXISTENCE_TARGET",
+  "status": "FRONTIER_OPEN",
+  "target": "EtaExistence",
+  "statement": "There exists eta > 0 such that rho_minus_pt(r1) >= eta.",
+  "minimal_missing_object": "analytic_eta_existence_proof",
+  "depends_on": [
+    "closed_form_rho_minus_pt_r1",
+    "declared_transition_shell_parameters",
+    "positivity_margin_argument"
+  ],
+  "does_not_prove": [
+    "eta exists",
+    "rho_minus_pt(r1) has been computed",
+    "first-cell positivity",
+    "multi-cell interval positivity",
+    "WEC/DEC closure",
+    "matching theorem",
+    "physical realization theorem",
+    "GRF theorem-level closure"
+  ]
+}

--- a/docs/essays/GRF_2026_ETA_EXISTENCE_TARGET.md
+++ b/docs/essays/GRF_2026_ETA_EXISTENCE_TARGET.md
@@ -1,0 +1,28 @@
+# GRF Eta Existence Target
+
+Status: `FRONTIER_OPEN`
+
+Target: `EtaExistence`
+
+Statement:
+
+There exists `eta > 0` such that
+
+```text
+rho_minus_pt(r1) >= eta
+Minimal missing object:
+analytic_eta_existence_proof
+Required ingredients:
+closed-form rho_minus_pt(r1)
+declared transition-shell parameters
+positivity margin argument
+Boundary:
+Does not prove:
+eta exists
+rho_minus_pt(r1) has been computed
+first-cell positivity
+multi-cell interval positivity
+WEC/DEC closure
+matching theorem
+physical realization theorem
+GRF theorem-level closure

--- a/scripts/verify_grf_eta_existence_target.py
+++ b/scripts/verify_grf_eta_existence_target.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT = ROOT / "artifacts/grf/eta_existence_target.json"
+DOC = ROOT / "docs/essays/GRF_2026_ETA_EXISTENCE_TARGET.md"
+
+REQUIRED_BOUNDARY = [
+    "eta exists",
+    "rho_minus_pt(r1) has been computed",
+    "first-cell positivity",
+    "multi-cell interval positivity",
+    "WEC/DEC closure",
+    "matching theorem",
+    "physical realization theorem",
+    "GRF theorem-level closure",
+]
+
+data = json.loads(ARTIFACT.read_text())
+doc = DOC.read_text()
+
+assert data["status"] == "FRONTIER_OPEN"
+assert data["target"] == "EtaExistence"
+assert data["minimal_missing_object"] == "analytic_eta_existence_proof"
+assert data["statement"] == "There exists eta > 0 such that rho_minus_pt(r1) >= eta."
+
+for token in REQUIRED_BOUNDARY:
+    assert token in data["does_not_prove"]
+    assert token in doc
+
+print("GRF eta existence target verified.")

--- a/tests/test_grf_eta_existence_target.py
+++ b/tests/test_grf_eta_existence_target.py
@@ -1,0 +1,26 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT = ROOT / "artifacts/grf/eta_existence_target.json"
+
+def test_eta_existence_target_shape():
+    data = json.loads(ARTIFACT.read_text())
+    assert data["status"] == "FRONTIER_OPEN"
+    assert data["target"] == "EtaExistence"
+    assert data["minimal_missing_object"] == "analytic_eta_existence_proof"
+
+def test_boundary_preserved():
+    data = json.loads(ARTIFACT.read_text())
+    assert "eta exists" in data["does_not_prove"]
+    assert "rho_minus_pt(r1) has been computed" in data["does_not_prove"]
+    assert "GRF theorem-level closure" in data["does_not_prove"]
+
+def test_verifier_passes():
+    subprocess.run(
+        [sys.executable, "scripts/verify_grf_eta_existence_target.py"],
+        cwd=ROOT,
+        check=True,
+    )


### PR DESCRIPTION
Adds the next GRF positive inner-boundary margin target:

`EtaExistence`

Statement:
There exists `eta > 0` such that `rho_minus_pt(r1) >= eta`.

Status:
`FRONTIER_OPEN`

Minimal missing object:
`analytic_eta_existence_proof`

Boundary:
Does not prove eta exists, rho_minus_pt(r1) has been computed, first-cell positivity, multi-cell interval positivity, WEC/DEC closure, matching theorem, physical realization theorem, or GRF theorem-level closure.

Verification:
- python3 -m py_compile scripts/verify_grf_eta_existence_target.py
- python3 -m py_compile tests/test_grf_eta_existence_target.py
- python3 scripts/verify_grf_eta_existence_target.py
- python3 -m pytest -q tests/test_grf_eta_existence_target.py
- git diff --check
