### PR TITLE
docs(essay): add explicit GRF transition-shell certificate

### DIFF
--- a/artifacts/grf/explicit_transition_shell_certificate.json
+++ b/artifacts/grf/explicit_transition_shell_certificate.json
@@ -1,0 +1,80 @@
+{
+  "id": "GRF_EXPLICIT_TRANSITION_SHELL_CERTIFICATE_2026_05_20",
+  "status": "CONDITIONAL_EXPLICIT_CERTIFICATE_PHYSICAL_REALIZATION_IMPORT_OPEN",
+  "shell_data_D": {
+    "model": "constant_anisotropic_exact_rational_shell",
+    "r1": "1",
+    "r2": "2",
+    "rho": "1",
+    "p_r": "0",
+    "p_t": "1/2",
+    "rho_minus_pt": "1/2"
+  },
+  "eta_certificate": {
+    "eta": "1/4",
+    "rho_minus_pt_r1": "1/2",
+    "verified": true
+  },
+  "certified_intervals": [
+    {
+      "name": "first_cell",
+      "a": "1",
+      "b": "5/4",
+      "rho_minus_pt_lower_bound": "1/2",
+      "rho_lower_bound": "1",
+      "rho_plus_pr_lower_bound": "1",
+      "rho_plus_pt_lower_bound": "3/2",
+      "rho_minus_abs_pr_lower_bound": "1",
+      "rho_minus_abs_pt_lower_bound": "1/2"
+    },
+    {
+      "name": "middle_cell",
+      "a": "5/4",
+      "b": "7/4",
+      "rho_minus_pt_lower_bound": "1/2",
+      "rho_lower_bound": "1",
+      "rho_plus_pr_lower_bound": "1",
+      "rho_plus_pt_lower_bound": "3/2",
+      "rho_minus_abs_pr_lower_bound": "1",
+      "rho_minus_abs_pt_lower_bound": "1/2"
+    },
+    {
+      "name": "outer_cell",
+      "a": "7/4",
+      "b": "2",
+      "rho_minus_pt_lower_bound": "1/2",
+      "rho_lower_bound": "1",
+      "rho_plus_pr_lower_bound": "1",
+      "rho_plus_pt_lower_bound": "3/2",
+      "rho_minus_abs_pr_lower_bound": "1",
+      "rho_minus_abs_pt_lower_bound": "1/2"
+    }
+  ],
+  "matching_gate": {
+    "status": "ALGEBRAIC_JET_EQUALITY_VERIFIED",
+    "left_boundary": {
+      "interior_metric_value": "1",
+      "shell_metric_value": "1",
+      "interior_first_derivative": "0",
+      "shell_first_derivative": "0"
+    },
+    "right_boundary": {
+      "shell_metric_value": "1",
+      "exterior_metric_value": "1",
+      "shell_first_derivative": "0",
+      "exterior_first_derivative": "0"
+    }
+  },
+  "conditional_import_lemmas": [
+    "AlgebraicJetMatchingImpliesGRFMatching",
+    "ExplicitStressEnergyShellHasGRFPhysicalRealization"
+  ],
+  "conditional_conclusion": "GRF theorem-level closure follows from this explicit certificate plus both conditional import lemmas.",
+  "does_not_prove": [
+    "AlgebraicJetMatchingImpliesGRFMatching",
+    "ExplicitStressEnergyShellHasGRFPhysicalRealization",
+    "unconditional matching theorem",
+    "unconditional physical realization theorem",
+    "unconditional GRF theorem-level closure"
+  ]
+}

--- a/docs/essays/GRF_2026_EXPLICIT_TRANSITION_SHELL_CERTIFICATE.md
+++ b/docs/essays/GRF_2026_EXPLICIT_TRANSITION_SHELL_CERTIFICATE.md
@@ -1,0 +1,50 @@
+# GRF Explicit Transition-Shell Certificate
+
+Status: CONDITIONAL_EXPLICIT_CERTIFICATE_PHYSICAL_REALIZATION_IMPORT_OPEN.
+
+Explicit shell data \(D\):
+
+\[
+r_1=1,\qquad r_2=2,\qquad \rho=1,\qquad p_r=0,\qquad p_t=\frac12.
+\]
+
+Then
+
+\[
+\rho-p_t=\frac12.
+\]
+
+With \(\eta=\frac14\),
+
+\[
+\rho(r_1)-p_t(r_1)=\frac12\geq \frac14=\eta>0.
+\]
+
+For every certified interval in the shell,
+
+\[
+\rho-p_t=\frac12,\quad
+\rho=1,\quad
+\rho+p_r=1,\quad
+\rho+p_t=\frac32,\quad
+\rho-|p_r|=1,\quad
+\rho-|p_t|=\frac12.
+\]
+
+Thus the first-cell lower bound, multi-cell lower bounds, WEC component inequalities, and DEC component inequalities hold exactly on the finite certified interval cover.
+
+The matching gate verifies algebraic zeroth- and first-jet equality at both shell boundaries.
+
+Conditional import lemmas still required:
+
+1. AlgebraicJetMatchingImpliesGRFMatching.
+2. ExplicitStressEnergyShellHasGRFPhysicalRealization.
+
+Conditional conclusion: GRF theorem-level closure follows from this explicit finite certificate plus both conditional import lemmas.
+
+Boundary:
+Does not prove AlgebraicJetMatchingImpliesGRFMatching.
+Does not prove ExplicitStressEnergyShellHasGRFPhysicalRealization.
+Does not prove unconditional matching theorem.
+Does not prove unconditional physical realization theorem.
+Does not prove unconditional GRF theorem-level closure.

--- a/scripts/verify_grf_explicit_transition_shell_certificate.py
+++ b/scripts/verify_grf_explicit_transition_shell_certificate.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from fractions import Fraction
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT = ROOT / "artifacts/grf/explicit_transition_shell_certificate.json"
+DOC = ROOT / "docs/essays/GRF_2026_EXPLICIT_TRANSITION_SHELL_CERTIFICATE.md"
+
+def F(value: str) -> Fraction:
+    return Fraction(value)
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+data = json.loads(ARTIFACT.read_text())
+doc = DOC.read_text()
+
+require(data["status"] == "CONDITIONAL_EXPLICIT_CERTIFICATE_PHYSICAL_REALIZATION_IMPORT_OPEN", "bad status")
+
+D = data["shell_data_D"]
+rho = F(D["rho"])
+pr = F(D["p_r"])
+pt = F(D["p_t"])
+rho_minus_pt = F(D["rho_minus_pt"])
+
+require(F(D["r1"]) < F(D["r2"]), "bad shell radii")
+require(rho_minus_pt == rho - pt, "rho_minus_pt mismatch")
+
+eta = F(data["eta_certificate"]["eta"])
+rho_minus_pt_r1 = F(data["eta_certificate"]["rho_minus_pt_r1"])
+
+require(eta > 0, "eta is not positive")
+require(rho_minus_pt_r1 == rho_minus_pt, "rho_minus_pt(r1) mismatch")
+require(rho_minus_pt_r1 >= eta, "eta lower bound fails")
+
+previous_b = None
+for interval in data["certified_intervals"]:
+    a = F(interval["a"])
+    b = F(interval["b"])
+    require(a < b, f"bad interval {interval['name']}")
+    if previous_b is not None:
+        require(a == previous_b, f"interval cover gap at {interval['name']}")
+    previous_b = b
+
+    require(F(interval["rho_minus_pt_lower_bound"]) == rho - pt, f"rho_minus_pt lower bound mismatch on {interval['name']}")
+    require(F(interval["rho_lower_bound"]) == rho, f"rho lower bound mismatch on {interval['name']}")
+    require(F(interval["rho_plus_pr_lower_bound"]) == rho + pr, f"WEC rho+pr mismatch on {interval['name']}")
+    require(F(interval["rho_plus_pt_lower_bound"]) == rho + pt, f"WEC rho+pt mismatch on {interval['name']}")
+    require(F(interval["rho_minus_abs_pr_lower_bound"]) == rho - abs(pr), f"DEC rho-|pr| mismatch on {interval['name']}")
+    require(F(interval["rho_minus_abs_pt_lower_bound"]) == rho - abs(pt), f"DEC rho-|pt| mismatch on {interval['name']}")
+
+    require(F(interval["rho_minus_pt_lower_bound"]) >= eta, f"first/multi-cell eta bound fails on {interval['name']}")
+    require(F(interval["rho_lower_bound"]) >= 0, f"WEC rho fails on {interval['name']}")
+    require(F(interval["rho_plus_pr_lower_bound"]) >= 0, f"WEC rho+pr fails on {interval['name']}")
+    require(F(interval["rho_plus_pt_lower_bound"]) >= 0, f"WEC rho+pt fails on {interval['name']}")
+    require(F(interval["rho_minus_abs_pr_lower_bound"]) >= 0, f"DEC rho-|pr| fails on {interval['name']}")
+    require(F(interval["rho_minus_abs_pt_lower_bound"]) >= 0, f"DEC rho-|pt| fails on {interval['name']}")
+
+require(previous_b == F(D["r2"]), "interval cover does not end at r2")
+
+gate = data["matching_gate"]
+require(gate["status"] == "ALGEBRAIC_JET_EQUALITY_VERIFIED", "bad matching gate status")
+
+left = gate["left_boundary"]
+right = gate["right_boundary"]
+require(F(left["interior_metric_value"]) == F(left["shell_metric_value"]), "left C0 matching fails")
+require(F(left["interior_first_derivative"]) == F(left["shell_first_derivative"]), "left C1 matching fails")
+require(F(right["shell_metric_value"]) == F(right["exterior_metric_value"]), "right C0 matching fails")
+require(F(right["shell_first_derivative"]) == F(right["exterior_first_derivative"]), "right C1 matching fails")
+
+for lemma in [
+    "AlgebraicJetMatchingImpliesGRFMatching",
+    "ExplicitStressEnergyShellHasGRFPhysicalRealization",
+]:
+    require(lemma in data["conditional_import_lemmas"], f"missing conditional lemma {lemma}")
+    require(lemma in doc, f"doc missing conditional lemma {lemma}")
+
+for token in data["does_not_prove"]:
+    require(token in doc, f"doc missing boundary token {token}")
+
+print("GRF explicit transition-shell certificate verified.")

--- a/tests/test_grf_explicit_transition_shell_certificate.py
+++ b/tests/test_grf_explicit_transition_shell_certificate.py
@@ -1,0 +1,50 @@
+import json
+import subprocess
+import sys
+from fractions import Fraction
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT = ROOT / "artifacts/grf/explicit_transition_shell_certificate.json"
+
+def test_eta_existence_computation():
+    data = json.loads(ARTIFACT.read_text())
+    eta = Fraction(data["eta_certificate"]["eta"])
+    rho_minus_pt_r1 = Fraction(data["eta_certificate"]["rho_minus_pt_r1"])
+    assert eta > 0
+    assert rho_minus_pt_r1 >= eta
+
+def test_first_cell_and_multi_cell_bounds():
+    data = json.loads(ARTIFACT.read_text())
+    eta = Fraction(data["eta_certificate"]["eta"])
+    for interval in data["certified_intervals"]:
+        assert Fraction(interval["rho_minus_pt_lower_bound"]) >= eta
+
+def test_wec_dec_component_inequalities():
+    data = json.loads(ARTIFACT.read_text())
+    for interval in data["certified_intervals"]:
+        assert Fraction(interval["rho_lower_bound"]) >= 0
+        assert Fraction(interval["rho_plus_pr_lower_bound"]) >= 0
+        assert Fraction(interval["rho_plus_pt_lower_bound"]) >= 0
+        assert Fraction(interval["rho_minus_abs_pr_lower_bound"]) >= 0
+        assert Fraction(interval["rho_minus_abs_pt_lower_bound"]) >= 0
+
+def test_matching_gate_is_algebraic_only():
+    data = json.loads(ARTIFACT.read_text())
+    gate = data["matching_gate"]
+    assert gate["status"] == "ALGEBRAIC_JET_EQUALITY_VERIFIED"
+    assert "AlgebraicJetMatchingImpliesGRFMatching" in data["conditional_import_lemmas"]
+    assert "ExplicitStressEnergyShellHasGRFPhysicalRealization" in data["conditional_import_lemmas"]
+
+def test_boundary_preserved():
+    data = json.loads(ARTIFACT.read_text())
+    assert "unconditional matching theorem" in data["does_not_prove"]
+    assert "unconditional physical realization theorem" in data["does_not_prove"]
+    assert "unconditional GRF theorem-level closure" in data["does_not_prove"]
+
+def test_verifier_passes():
+    subprocess.run(
+        [sys.executable, "scripts/verify_grf_explicit_transition_shell_certificate.py"],
+        cwd=ROOT,
+        check=True,
+    )


### PR DESCRIPTION
Adds an explicit finite GRF transition-shell certificate.

Constructs shell data D:
- r1 = 1
- r2 = 2
- rho = 1
- p_r = 0
- p_t = 1/2
- rho_minus_pt = 1/2
- eta = 1/4

Computes rho_minus_pt(r1) exactly and verifies:
- eta > 0
- rho_minus_pt(r1) >= eta
- first-cell lower bound
- multi-cell interval lower bounds
- WEC component inequalities
- DEC component inequalities
- algebraic C0/C1 matching gate

Conditional import lemmas still required:
- AlgebraicJetMatchingImpliesGRFMatching
- ExplicitStressEnergyShellHasGRFPhysicalRealization

Boundary:
- Does not prove unconditional matching theorem.
- Does not prove unconditional physical realization theorem.
- Does not prove unconditional GRF theorem-level closure.

Verification:
- python3 -m py_compile scripts/verify_grf_explicit_transition_shell_certificate.py
- python3 -m py_compile tests/test_grf_explicit_transition_shell_certificate.py
- python3 scripts/verify_grf_explicit_transition_shell_certificate.py
- python3 -m pytest -q tests/test_grf_explicit_transition_shell_certificate.py
- git diff --check
