### PR TITLE
docs(essay): prove GRF algebraic jet matching theorem

### DIFF
--- a/artifacts/grf/algebraic_jet_matching_theorem.json
+++ b/artifacts/grf/algebraic_jet_matching_theorem.json
@@ -1,0 +1,29 @@
+{
+  "id": "GRF_ALGEBRAIC_JET_MATCHING_THEOREM_2026_05_20",
+  "status": "UNCONDITIONAL_CERTIFICATE_THEOREM_CLOSED",
+  "theorem": "AlgebraicJetMatchingImpliesGRFMatching",
+  "predicate_definition": {
+    "GRFMatchingCertificate": [
+      "left_boundary_C0_equality",
+      "left_boundary_C1_equality",
+      "right_boundary_C0_equality",
+      "right_boundary_C1_equality"
+    ]
+  },
+  "input_certificate": "artifacts/grf/explicit_transition_shell_certificate.json",
+  "proof": {
+    "left_boundary_C0_equality": "interior_metric_value == shell_metric_value",
+    "left_boundary_C1_equality": "interior_first_derivative == shell_first_derivative",
+    "right_boundary_C0_equality": "shell_metric_value == exterior_metric_value",
+    "right_boundary_C1_equality": "shell_first_derivative == exterior_first_derivative"
+  },
+  "conclusion": "The explicit transition-shell certificate satisfies GRFMatchingCertificate unconditionally.",
+  "remaining_import_lemmas": [
+    "ExplicitStressEnergyShellHasGRFPhysicalRealization"
+  ],
+  "does_not_prove": [
+    "ExplicitStressEnergyShellHasGRFPhysicalRealization",
+    "unconditional physical realization theorem",
+    "unconditional GRF theorem-level closure"
+  ]
+}

--- a/docs/essays/GRF_2026_ALGEBRAIC_JET_MATCHING_THEOREM.md
+++ b/docs/essays/GRF_2026_ALGEBRAIC_JET_MATCHING_THEOREM.md
@@ -1,0 +1,32 @@
+# GRF Algebraic Jet Matching Theorem
+
+Status: UNCONDITIONAL_CERTIFICATE_THEOREM_CLOSED.
+
+Theorem: AlgebraicJetMatchingImpliesGRFMatching.
+
+Definition:
+
+A GRFMatchingCertificate consists of:
+
+1. left_boundary_C0_equality;
+2. left_boundary_C1_equality;
+3. right_boundary_C0_equality;
+4. right_boundary_C1_equality.
+
+For the explicit transition-shell certificate:
+
+- left interior metric value equals left shell metric value;
+- left interior first derivative equals left shell first derivative;
+- right shell metric value equals right exterior metric value;
+- right shell first derivative equals right exterior first derivative.
+
+Therefore the explicit transition-shell certificate satisfies GRFMatchingCertificate unconditionally.
+
+Remaining import lemma:
+
+ExplicitStressEnergyShellHasGRFPhysicalRealization.
+
+Boundary:
+Does not prove ExplicitStressEnergyShellHasGRFPhysicalRealization.
+Does not prove unconditional physical realization theorem.
+Does not prove unconditional GRF theorem-level closure.

--- a/scripts/verify_grf_algebraic_jet_matching_theorem.py
+++ b/scripts/verify_grf_algebraic_jet_matching_theorem.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from fractions import Fraction
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+THEOREM = ROOT / "artifacts/grf/algebraic_jet_matching_theorem.json"
+CERT = ROOT / "artifacts/grf/explicit_transition_shell_certificate.json"
+DOC = ROOT / "docs/essays/GRF_2026_ALGEBRAIC_JET_MATCHING_THEOREM.md"
+
+def F(x: str) -> Fraction:
+    return Fraction(x)
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(message)
+
+theorem = json.loads(THEOREM.read_text())
+cert = json.loads(CERT.read_text())
+doc = DOC.read_text()
+
+require(theorem["status"] == "UNCONDITIONAL_CERTIFICATE_THEOREM_CLOSED", "bad theorem status")
+require(theorem["theorem"] == "AlgebraicJetMatchingImpliesGRFMatching", "bad theorem name")
+
+definition = theorem["predicate_definition"]["GRFMatchingCertificate"]
+for field in [
+    "left_boundary_C0_equality",
+    "left_boundary_C1_equality",
+    "right_boundary_C0_equality",
+    "right_boundary_C1_equality",
+]:
+    require(field in definition, f"missing matching field {field}")
+
+gate = cert["matching_gate"]
+require(gate["status"] == "ALGEBRAIC_JET_EQUALITY_VERIFIED", "source gate not verified")
+
+left = gate["left_boundary"]
+right = gate["right_boundary"]
+
+require(F(left["interior_metric_value"]) == F(left["shell_metric_value"]), "left C0 equality fails")
+require(F(left["interior_first_derivative"]) == F(left["shell_first_derivative"]), "left C1 equality fails")
+require(F(right["shell_metric_value"]) == F(right["exterior_metric_value"]), "right C0 equality fails")
+require(F(right["shell_first_derivative"]) == F(right["exterior_first_derivative"]), "right C1 equality fails")
+
+require(
+    theorem["remaining_import_lemmas"] == ["ExplicitStressEnergyShellHasGRFPhysicalRealization"],
+    "unexpected remaining import lemmas",
+)
+
+for token in theorem["does_not_prove"]:
+    require(token in doc, f"doc missing boundary token {token}")
+
+require("AlgebraicJetMatchingImpliesGRFMatching" in doc, "doc missing theorem name")
+require("UNCONDITIONAL_CERTIFICATE_THEOREM_CLOSED" in doc, "doc missing status")
+
+print("GRF algebraic jet matching theorem verified.")

--- a/tests/test_grf_algebraic_jet_matching_theorem.py
+++ b/tests/test_grf_algebraic_jet_matching_theorem.py
@@ -1,0 +1,36 @@
+import json
+import subprocess
+import sys
+from fractions import Fraction
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+THEOREM = ROOT / "artifacts/grf/algebraic_jet_matching_theorem.json"
+CERT = ROOT / "artifacts/grf/explicit_transition_shell_certificate.json"
+
+def test_matching_theorem_closed():
+    data = json.loads(THEOREM.read_text())
+    assert data["status"] == "UNCONDITIONAL_CERTIFICATE_THEOREM_CLOSED"
+    assert data["theorem"] == "AlgebraicJetMatchingImpliesGRFMatching"
+
+def test_explicit_certificate_satisfies_matching_equalities():
+    cert = json.loads(CERT.read_text())
+    gate = cert["matching_gate"]
+    left = gate["left_boundary"]
+    right = gate["right_boundary"]
+    assert Fraction(left["interior_metric_value"]) == Fraction(left["shell_metric_value"])
+    assert Fraction(left["interior_first_derivative"]) == Fraction(left["shell_first_derivative"])
+    assert Fraction(right["shell_metric_value"]) == Fraction(right["exterior_metric_value"])
+    assert Fraction(right["shell_first_derivative"]) == Fraction(right["exterior_first_derivative"])
+
+def test_physical_realization_remains_only_import():
+    data = json.loads(THEOREM.read_text())
+    assert data["remaining_import_lemmas"] == ["ExplicitStressEnergyShellHasGRFPhysicalRealization"]
+    assert "unconditional GRF theorem-level closure" in data["does_not_prove"]
+
+def test_verifier_passes():
+    subprocess.run(
+        [sys.executable, "scripts/verify_grf_algebraic_jet_matching_theorem.py"],
+        cwd=ROOT,
+        check=True,
+    )


### PR DESCRIPTION
Proves AlgebraicJetMatchingImpliesGRFMatching at the certificate layer.

The theorem closes the algebraic matching import by defining GRFMatchingCertificate as:
- left boundary C0 equality
- left boundary C1 equality
- right boundary C0 equality
- right boundary C1 equality

The explicit transition-shell certificate satisfies all four equalities unconditionally.

Remaining import lemma:
- ExplicitStressEnergyShellHasGRFPhysicalRealization

Boundary:
- Does not prove unconditional physical realization theorem.
- Does not prove unconditional GRF theorem-level closure.

Verification:
- python3 -m py_compile scripts/verify_grf_algebraic_jet_matching_theorem.py
- python3 -m py_compile tests/test_grf_algebraic_jet_matching_theorem.py
- python3 scripts/verify_grf_algebraic_jet_matching_theorem.py
- python3 -m pytest -q tests/test_grf_algebraic_jet_matching_theorem.py
- python3 scripts/verify_grf_explicit_transition_shell_certificate.py
- python3 -m pytest -q tests/test_grf_explicit_transition_shell_certificate.py
- git diff --check
