### PR TITLE
docs: add manuscript full chapter expansion target

### DIFF
--- a/artifacts/manuscript/manuscript_full_chapter_expansion_target_2026_05_20.json
+++ b/artifacts/manuscript/manuscript_full_chapter_expansion_target_2026_05_20.json
@@ -1,0 +1,98 @@
+{
+  "id": "MANUSCRIPT_FULL_CHAPTER_EXPANSION_TARGET",
+  "date": "2026-05-20",
+  "repository": "urf-textbook",
+  "status": "TEXTBOOK_MANUSCRIPT_INCOMPLETE_FULL_EXPANSION_TARGET_DEFINED",
+  "depends_on": [
+    "MANUSCRIPT_CHAPTER_COMPLETENESS_AUDIT"
+  ],
+  "chapter_directory": "manuscript/chapters",
+  "required_expansion_units_per_chapter": [
+    "chapter purpose",
+    "core definitions",
+    "main statements",
+    "proof/explanation layer",
+    "dependency notes",
+    "boundary statement",
+    "exercises or review prompts"
+  ],
+  "chapter_targets": {
+    "00_preface.tex": [
+      "scope of URF textbook",
+      "reader prerequisites",
+      "claim-boundary discipline",
+      "map of verified versus expository layers"
+    ],
+    "01_foundations.tex": [
+      "refinement systems",
+      "transcripts",
+      "capacity bounds",
+      "entropy bookkeeping",
+      "worked toy example"
+    ],
+    "02_refinement_locality.tex": [
+      "locality models",
+      "normalization principles",
+      "local-to-global obstruction shape",
+      "examples and non-examples"
+    ],
+    "03_core_lemmas.tex": [
+      "chain rule",
+      "non-amplification",
+      "terminal obstruction",
+      "dependency graph"
+    ],
+    "04_main_theorems.tex": [
+      "capacity accumulation theorem",
+      "depth lower bound",
+      "operational rigidity theorem",
+      "hypothesis checklist"
+    ],
+    "05_examples_sat.tex": [
+      "search as refinement",
+      "SAT witness-space example",
+      "limits of the exposition",
+      "P-vs-NP no-claim boundary"
+    ],
+    "06_examples_ym.tex": [
+      "gauge-compatible refinement",
+      "coercivity dependency",
+      "mass-gap missing objects",
+      "Clay no-claim boundary"
+    ],
+    "07_examples_rh.tex": [
+      "spectral certificate interface",
+      "zero-detection map",
+      "arithmetic soundness bridge",
+      "RH no-claim boundary"
+    ],
+    "08_examples_ns.tex": [
+      "energy and dissipation",
+      "regularity certificate",
+      "blow-up exclusion interface",
+      "Navier-Stokes no-claim boundary"
+    ],
+    "09_examples_exchange.tex": [
+      "exchange constraints",
+      "finite transition gates",
+      "rigidity interpretation",
+      "physical overclaim boundary"
+    ]
+  },
+  "completion_gate": {
+    "minimum_nonempty_lines_per_chapter": 80,
+    "minimum_sections_per_chapter": 4,
+    "minimum_theorem_style_blocks_per_chapter": 2,
+    "requires_boundary_statement": true,
+    "requires_exercises_or_review_prompts": true
+  },
+  "boundary": [
+    "target definition only",
+    "does not complete the textbook",
+    "does not prove a new theorem",
+    "does not close Chronos-RR",
+    "does not close H4.1/FGL",
+    "does not prove P vs NP",
+    "does not prove any Clay problem"
+  ]
+}

--- a/docs/status/MANUSCRIPT_FULL_CHAPTER_EXPANSION_TARGET_2026_05_20.md
+++ b/docs/status/MANUSCRIPT_FULL_CHAPTER_EXPANSION_TARGET_2026_05_20.md
@@ -1,0 +1,29 @@
+# MANUSCRIPT_FULL_CHAPTER_EXPANSION_TARGET
+
+Status: `TEXTBOOK_MANUSCRIPT_INCOMPLETE_FULL_EXPANSION_TARGET_DEFINED`
+
+This target follows the merged `MANUSCRIPT_CHAPTER_COMPLETENESS_AUDIT`.
+
+The prior audit repaired the chapter layer from broken/skeletal status into a verified minimum skeleton.  This target defines the next stricter completion gate: full chapter expansion.
+
+A full chapter must eventually contain:
+
+- chapter purpose;
+- core definitions;
+- main statements;
+- proof or explanation layer;
+- dependency notes;
+- boundary statement;
+- exercises or review prompts.
+
+Completion gate:
+
+- at least 80 nonempty lines per chapter;
+- at least 4 sections per chapter;
+- at least 2 theorem-style blocks per chapter;
+- explicit boundary statement;
+- exercises or review prompts.
+
+Boundary:
+
+This is a target-definition pass only.  It does not complete the textbook, does not prove a new theorem, does not close Chronos-RR, does not close H4.1/FGL, does not prove P vs NP, and does not prove any Clay problem.

--- a/scripts/verify_manuscript_full_chapter_expansion_target.py
+++ b/scripts/verify_manuscript_full_chapter_expansion_target.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+ARTIFACT = ROOT / "artifacts/manuscript/manuscript_full_chapter_expansion_target_2026_05_20.json"
+STATUS_DOC = ROOT / "docs/status/MANUSCRIPT_FULL_CHAPTER_EXPANSION_TARGET_2026_05_20.md"
+
+REQUIRED_CHAPTERS = [
+    "00_preface.tex",
+    "01_foundations.tex",
+    "02_refinement_locality.tex",
+    "03_core_lemmas.tex",
+    "04_main_theorems.tex",
+    "05_examples_sat.tex",
+    "06_examples_ym.tex",
+    "07_examples_rh.tex",
+    "08_examples_ns.tex",
+    "09_examples_exchange.tex",
+]
+
+REQUIRED_BOUNDARY_TOKENS = [
+    "does not complete the textbook",
+    "does not prove a new theorem",
+    "does not close Chronos-RR",
+    "does not close H4.1/FGL",
+    "does not prove P vs NP",
+    "does not prove any Clay problem",
+]
+
+def fail(msg: str) -> int:
+    print(f"MANUSCRIPT_FULL_CHAPTER_EXPANSION_TARGET failed: {msg}")
+    return 1
+
+def main() -> int:
+    if not ARTIFACT.exists():
+        return fail("missing artifact")
+    if not STATUS_DOC.exists():
+        return fail("missing status doc")
+
+    data = json.loads(ARTIFACT.read_text(encoding="utf-8"))
+
+    if data.get("id") != "MANUSCRIPT_FULL_CHAPTER_EXPANSION_TARGET":
+        return fail("artifact id mismatch")
+
+    if data.get("status") != "TEXTBOOK_MANUSCRIPT_INCOMPLETE_FULL_EXPANSION_TARGET_DEFINED":
+        return fail("artifact status mismatch")
+
+    if "MANUSCRIPT_CHAPTER_COMPLETENESS_AUDIT" not in data.get("depends_on", []):
+        return fail("missing dependency on chapter completeness audit")
+
+    targets = data.get("chapter_targets", {})
+    for chapter in REQUIRED_CHAPTERS:
+        if chapter not in targets:
+            return fail(f"missing chapter target: {chapter}")
+        if len(targets[chapter]) < 4:
+            return fail(f"chapter target too weak: {chapter}")
+
+    gate = data.get("completion_gate", {})
+    if gate.get("minimum_nonempty_lines_per_chapter") != 80:
+        return fail("minimum nonempty line gate mismatch")
+    if gate.get("minimum_sections_per_chapter") != 4:
+        return fail("minimum section gate mismatch")
+    if gate.get("minimum_theorem_style_blocks_per_chapter") != 2:
+        return fail("minimum theorem-style block gate mismatch")
+    if gate.get("requires_boundary_statement") is not True:
+        return fail("missing boundary requirement")
+    if gate.get("requires_exercises_or_review_prompts") is not True:
+        return fail("missing exercises/review requirement")
+
+    artifact_text = ARTIFACT.read_text(encoding="utf-8")
+    status_text = STATUS_DOC.read_text(encoding="utf-8")
+
+    for token in REQUIRED_BOUNDARY_TOKENS:
+        if token not in artifact_text:
+            return fail(f"artifact missing boundary token: {token}")
+        if token not in status_text:
+            return fail(f"status doc missing boundary token: {token}")
+
+    for token in [
+        "TEXTBOOK_MANUSCRIPT_INCOMPLETE_FULL_EXPANSION_TARGET_DEFINED",
+        "full chapter expansion",
+        "at least 80 nonempty lines per chapter",
+        "at least 4 sections per chapter",
+        "at least 2 theorem-style blocks per chapter",
+    ]:
+        if token not in status_text:
+            return fail(f"status doc missing token: {token}")
+
+    print("MANUSCRIPT_FULL_CHAPTER_EXPANSION_TARGET verified.")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_manuscript_full_chapter_expansion_target.py
+++ b/tests/test_manuscript_full_chapter_expansion_target.py
@@ -1,0 +1,11 @@
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+def test_manuscript_full_chapter_expansion_target_verifier_passes():
+    subprocess.run(
+        ["python3", "scripts/verify_manuscript_full_chapter_expansion_target.py"],
+        cwd=ROOT,
+        check=True,
+    )


### PR DESCRIPTION
Adds `MANUSCRIPT_FULL_CHAPTER_EXPANSION_TARGET`.

This follows the merged chapter-completeness audit and defines the next stricter gate for full textbook expansion.

Included:
- full chapter expansion artifact
- status document
- verifier
- pytest coverage

Verification:
- python3 scripts/verify_manuscript_chapter_completeness_audit.py
- python3 -m pytest -q tests/test_manuscript_chapter_completeness_audit.py
- python3 scripts/verify_manuscript_full_chapter_expansion_target.py
- python3 -m pytest -q tests/test_manuscript_full_chapter_expansion_target.py
- git diff --check

Boundary:
Target-definition pass only. Does not complete the textbook, does not prove a new theorem, does not close Chronos-RR, does not close H4.1/FGL, does not prove P vs NP, and does not prove any Clay problem.
