### PR TITLE
docs: backfill v0.1.2 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.1.2 — 2026-03-01
+
+Release class: Infrastructure consolidation release.
+
+Added release metadata coverage for the v0.1.2 frozen PDF/checksum artifact pair.
+
+Assets:
+
+- `releases/v0.1.2/urf-textbook-v0.1.2.pdf`
+- `releases/v0.1.2/SHA256.txt`
+- `releases/v0.1.2/README.md`
+- `docs/release_notes/v0.1.2.md`
+
+Boundary: documentation/release metadata only; no unrestricted Chronos-RR, unrestricted H4.1/FGL, P vs NP, any Clay problem, or theorem-level closure is asserted.
+
 All notable changes to the URF Textbook will be documented in this file.
 
 The format follows Keep a Changelog principles.

--- a/docs/release_notes/v0.1.2.md
+++ b/docs/release_notes/v0.1.2.md
@@ -1,0 +1,50 @@
+# URF Textbook — Release Notes v0.1.2
+
+Repository: `inaciovasquez2020/urf-textbook`
+Release tag: `v0.1.2`
+Release date: 2026-03-01
+Release commit: `fc46aa7`
+Release class: Infrastructure consolidation release
+
+## Overview
+
+Version v0.1.2 is an infrastructure consolidation release for the URF Textbook.
+
+The release preserves a PDF artifact and checksum manifest while marking the release as a repository and release-management checkpoint rather than a theorem-bearing mathematical closure event.
+
+## Release Assets
+
+- `releases/v0.1.2/urf-textbook-v0.1.2.pdf`
+- `releases/v0.1.2/SHA256.txt`
+- `releases/v0.1.2/README.md`
+
+## Integrity Record
+
+SHA-256 manifest entry:
+
+```text
+b4704ca9a791346585826a02dc1baf184c0d6f7f6e7fd9a3aedda0bfc2ef059e urf-textbook-v0.1.2.pdf
+```
+
+## Repository Role
+
+This release supports:
+
+- reproducible archival reference;
+- stable release navigation;
+- checksum-based asset verification;
+- continuity between earlier release assets and later release notes.
+
+## Boundary
+
+Status: Documentation/release metadata only.
+
+Does not prove:
+
+- unrestricted Chronos-RR;
+- unrestricted H4.1/FGL;
+- P vs NP;
+- any Clay problem;
+- any theorem-level closure not explicitly inherited from a buildable formal source repository.
+
+The URF Textbook is an exposition and release-facing documentation layer. Any theorem-level claim must inherit from a buildable formal source repository and identify repository, commit or release, file path, theorem or artifact name, and status label.

--- a/releases/v0.1.2/README.md
+++ b/releases/v0.1.2/README.md
@@ -1,0 +1,49 @@
+# URF Textbook v0.1.2 Release Capsule
+
+Release tag: `v0.1.2`
+Release date: 2026-03-01
+Release commit: `fc46aa7`
+Release class: Infrastructure consolidation release
+
+## Assets
+
+- `urf-textbook-v0.1.2.pdf`
+- `SHA256.txt`
+
+## Integrity
+
+Recorded SHA-256:
+
+```text
+b4704ca9a791346585826a02dc1baf184c0d6f7f6e7fd9a3aedda0bfc2ef059e urf-textbook-v0.1.2.pdf
+```
+
+## Purpose
+
+This release records the v0.1.2 infrastructure consolidation checkpoint for the URF Textbook release line.
+
+Its function is archival and navigational:
+
+- preserve the frozen PDF asset;
+- preserve the checksum manifest;
+- identify the release tag and commit;
+- explain that this release consolidated repository and release infrastructure rather than adding a theorem-level mathematical result;
+- give future readers a stable capsule for what v0.1.2 was.
+
+## Status
+
+Status: Documentation/release metadata only.
+
+This release capsule does not assert theorem-level closure.
+
+Does not prove:
+
+- unrestricted Chronos-RR;
+- unrestricted H4.1/FGL;
+- P vs NP;
+- any Clay problem;
+- any theorem-level closure not explicitly inherited from a buildable formal source repository.
+
+## Source-of-Truth Boundary
+
+The URF Textbook is an exposition and release-facing documentation layer. Any theorem-level claim must inherit from a buildable formal source repository and identify repository, commit or release, file path, theorem or artifact name, and status label.

--- a/tests/test_v012_release_metadata.py
+++ b/tests/test_v012_release_metadata.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_FILES = [
+    ROOT / "releases/v0.1.2/urf-textbook-v0.1.2.pdf",
+    ROOT / "releases/v0.1.2/SHA256.txt",
+    ROOT / "releases/v0.1.2/README.md",
+    ROOT / "docs/release_notes/v0.1.2.md",
+    ROOT / "CHANGELOG.md",
+]
+
+REQUIRED_TOKENS = [
+    "v0.1.2",
+    "Infrastructure consolidation release",
+    "b4704ca9a791346585826a02dc1baf184c0d6f7f6e7fd9a3aedda0bfc2ef059e",
+    "Documentation/release metadata only",
+    "Does not prove:",
+    "unrestricted Chronos-RR",
+    "unrestricted H4.1/FGL",
+    "P vs NP",
+    "any Clay problem",
+]
+
+def test_v012_release_metadata_files_exist():
+    for path in REQUIRED_FILES:
+        assert path.exists(), str(path)
+
+def test_v012_release_metadata_contains_boundary_tokens():
+    combined = "\n".join(
+        path.read_text(errors="ignore")
+        for path in [
+            ROOT / "releases/v0.1.2/README.md",
+            ROOT / "docs/release_notes/v0.1.2.md",
+            ROOT / "CHANGELOG.md",
+        ]
+    )
+    for token in REQUIRED_TOKENS:
+        assert token in combined, token


### PR DESCRIPTION
Backfills the missing v0.1.2 release metadata capsule, release notes, changelog entry, and regression test. Boundary: documentation/release metadata only; no theorem-level closure, no unrestricted Chronos-RR, no unrestricted H4.1/FGL, no P vs NP, and no Clay problem.