### PR TITLE
docs: review v0.1.2 page 1 source-location gap

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -20,7 +20,7 @@ Does not prove:
 
 | Page | Extract | Status | Needed update |
 |---:|---|---|---|
-| 1 | `docs/page_audits/v0.1.2/page_1.txt` | OPEN | Pending page review. |
+| 1 | `docs/page_audits/v0.1.2/page_1.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED | Source file for Preface page not yet located; see `docs/page_audits/v0.1.2/reviews/page_1_review.md`. |
 | 2 | `docs/page_audits/v0.1.2/page_2.txt` | OPEN | Pending page review. |
 | 3 | `docs/page_audits/v0.1.2/page_3.txt` | OPEN | Pending page review. |
 | 4 | `docs/page_audits/v0.1.2/page_4.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_1_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_1_review.md
@@ -1,0 +1,33 @@
+# v0.1.2 Page 1 Review
+
+Page: 1
+Extract: `docs/page_audits/v0.1.2/page_1.txt`
+Status: `SOURCE_OR_RELEASE_METADATA_NEEDED`
+
+## Finding
+
+Page 1 is the Preface page. The extracted text introduces the central thesis:
+
+> Global behavior is constrained by local capacity bounds.
+
+The page is acceptable as exposition, but the repository source file that generated this page was not located by the first automated source search.
+
+## Update
+
+No source text was modified in this step.
+
+This review records the missing source-location object for page 1.
+
+## Required Next Object
+
+Locate the source file that generates page 1 of `releases/v0.1.2/urf-textbook-v0.1.2.pdf`, then add the Preface source-of-truth boundary note there.
+
+## Boundary
+
+Does not prove:
+
+- unrestricted Chronos-RR;
+- unrestricted H4.1/FGL;
+- P vs NP;
+- any Clay problem;
+- any theorem-level closure not explicitly inherited from a buildable formal source repository.

--- a/tests/test_v012_page_01_source_location_gap.py
+++ b/tests/test_v012_page_01_source_location_gap.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_1_review.md"
+EXTRACT = ROOT / "docs/page_audits/v0.1.2/page_1.txt"
+
+def test_page_01_review_records_source_location_gap():
+    assert REVIEW.exists()
+    text = REVIEW.read_text()
+    required = [
+        "Status: `SOURCE_OR_RELEASE_METADATA_NEEDED`",
+        "Global behavior is constrained by local capacity bounds",
+        "source file that generated this page was not located",
+        "Required Next Object",
+        "Does not prove:",
+        "unrestricted Chronos-RR",
+        "unrestricted H4.1/FGL",
+        "P vs NP",
+        "any Clay problem",
+    ]
+    for token in required:
+        assert token in text, token
+
+def test_page_01_plan_row_records_source_location_gap():
+    text = PLAN.read_text()
+    assert "| 1 | `docs/page_audits/v0.1.2/page_1.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED |" in text
+    assert "page_1_review.md" in text
+
+def test_page_01_extract_contains_preface_thesis():
+    text = EXTRACT.read_text(errors="ignore")
+    assert "Preface" in text
+    assert "Global behavior is constrained by local capacity bounds" in text


### PR DESCRIPTION
Reviews v0.1.2 page 1 and records the missing source-location object instead of modifying an unlocated source file. Boundary: page-1 audit metadata only; no theorem-level closure, no unrestricted Chronos-RR, no unrestricted H4.1/FGL, no P vs NP, and no Clay problem.