### PR TITLE
docs: review v0.1.2 page 2 number-only extract

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -21,7 +21,7 @@ Does not prove:
 | Page | Extract | Status | Needed update |
 |---:|---|---|---|
 | 1 | `docs/page_audits/v0.1.2/page_1.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED | Source file for Preface page not yet located; see `docs/page_audits/v0.1.2/reviews/page_1_review.md`. |
-| 2 | `docs/page_audits/v0.1.2/page_2.txt` | OPEN | Pending page review. |
+| 2 | `docs/page_audits/v0.1.2/page_2.txt` | NO_CHANGE | Page-number-only extract; see `docs/page_audits/v0.1.2/reviews/page_2_review.md`. |
 | 3 | `docs/page_audits/v0.1.2/page_3.txt` | OPEN | Pending page review. |
 | 4 | `docs/page_audits/v0.1.2/page_4.txt` | OPEN | Pending page review. |
 | 5 | `docs/page_audits/v0.1.2/page_5.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_2_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_2_review.md
@@ -1,0 +1,25 @@
+# v0.1.2 Page 2 Review
+
+Page: 2
+Extract: `docs/page_audits/v0.1.2/page_2.txt`
+Status: `NO_CHANGE`
+
+## Finding
+
+Page 2 contains only the extracted page marker `2`.
+
+There is no substantive mathematical, expository, metadata, or boundary text on this page.
+
+## Update
+
+No content update is required for page 2.
+
+## Boundary
+
+Does not prove:
+
+- unrestricted Chronos-RR;
+- unrestricted H4.1/FGL;
+- P vs NP;
+- any Clay problem;
+- any theorem-level closure not explicitly inherited from a buildable formal source repository.

--- a/tests/test_v012_page_02_number_only_no_change.py
+++ b/tests/test_v012_page_02_number_only_no_change.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_2_review.md"
+EXTRACT = ROOT / "docs/page_audits/v0.1.2/page_2.txt"
+
+def test_page_02_extract_is_number_only():
+    assert EXTRACT.read_text(errors="ignore").strip() == "2"
+
+def test_page_02_review_records_no_change():
+    assert REVIEW.exists()
+    text = REVIEW.read_text()
+    required = [
+        "Status: `NO_CHANGE`",
+        "Page 2 contains only the extracted page marker `2`",
+        "No content update is required for page 2",
+        "Does not prove:",
+        "unrestricted Chronos-RR",
+        "unrestricted H4.1/FGL",
+        "P vs NP",
+        "any Clay problem",
+    ]
+    for token in required:
+        assert token in text, token
+
+def test_page_02_plan_row_records_no_change():
+    text = PLAN.read_text()
+    assert "| 2 | `docs/page_audits/v0.1.2/page_2.txt` | NO_CHANGE |" in text
+    assert "page_2_review.md" in text


### PR DESCRIPTION
Reviews v0.1.2 page 2 and records it as a number-only/no-change page. Boundary: page-2 audit metadata only; no theorem-level closure, no unrestricted Chronos-RR, no unrestricted H4.1/FGL, no P vs NP, and no Clay problem.