### PR TITLE
docs: review v0.1.2 page 3 title release metadata

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -22,7 +22,7 @@ Does not prove:
 |---:|---|---|---|
 | 1 | `docs/page_audits/v0.1.2/page_1.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED | Source file for Preface page not yet located; see `docs/page_audits/v0.1.2/reviews/page_1_review.md`. |
 | 2 | `docs/page_audits/v0.1.2/page_2.txt` | NO_CHANGE | Page-number-only extract; see `docs/page_audits/v0.1.2/reviews/page_2_review.md`. |
-| 3 | `docs/page_audits/v0.1.2/page_3.txt` | OPEN | Pending page review. |
+| 3 | `docs/page_audits/v0.1.2/page_3.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED | Title page lacks explicit `v0.1.2` release identifier; see `docs/page_audits/v0.1.2/reviews/page_3_review.md`. |
 | 4 | `docs/page_audits/v0.1.2/page_4.txt` | OPEN | Pending page review. |
 | 5 | `docs/page_audits/v0.1.2/page_5.txt` | OPEN | Pending page review. |
 | 6 | `docs/page_audits/v0.1.2/page_6.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_3_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_3_review.md
@@ -1,0 +1,40 @@
+# v0.1.2 Page 3 Review
+
+Page: 3
+Extract: `docs/page_audits/v0.1.2/page_3.txt`
+Status: `SOURCE_OR_RELEASE_METADATA_NEEDED`
+
+## Finding
+
+Page 3 is the title page.
+
+It identifies:
+
+- title: `Unified Rigidity Framework Textbook`
+- subtitle/context: `Capacity, Locality, and Terminal Obstructions`
+- author: `Inacio Vasquez`
+- date: `March 1, 2026`
+
+The page does not explicitly identify the frozen release version `v0.1.2`.
+
+## Update
+
+No PDF source text was modified in this step.
+
+This review records the missing title-page release metadata object.
+
+## Required Next Object
+
+Locate the source file that generates the title page, then add the weakest release identifier:
+
+`Release: v0.1.2`
+
+## Boundary
+
+Does not prove:
+
+- unrestricted Chronos-RR;
+- unrestricted H4.1/FGL;
+- P vs NP;
+- any Clay problem;
+- any theorem-level closure not explicitly inherited from a buildable formal source repository.

--- a/tests/test_v012_page_03_title_release_metadata.py
+++ b/tests/test_v012_page_03_title_release_metadata.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_3_review.md"
+EXTRACT = ROOT / "docs/page_audits/v0.1.2/page_3.txt"
+
+def test_page_03_extract_is_title_page():
+    text = EXTRACT.read_text(errors="ignore")
+    required = [
+        "Unified Rigidity Framework Textbook",
+        "Capacity, Locality, and Terminal Obstructions",
+        "Inacio Vasquez",
+        "March 1, 2026",
+    ]
+    for token in required:
+        assert token in text, token
+
+def test_page_03_review_records_release_metadata_gap():
+    assert REVIEW.exists()
+    text = REVIEW.read_text()
+    required = [
+        "Status: `SOURCE_OR_RELEASE_METADATA_NEEDED`",
+        "Page 3 is the title page",
+        "does not explicitly identify the frozen release version `v0.1.2`",
+        "Release: v0.1.2",
+        "Does not prove:",
+        "unrestricted Chronos-RR",
+        "unrestricted H4.1/FGL",
+        "P vs NP",
+        "any Clay problem",
+    ]
+    for token in required:
+        assert token in text, token
+
+def test_page_03_plan_row_records_release_metadata_gap():
+    text = PLAN.read_text()
+    assert "| 3 | `docs/page_audits/v0.1.2/page_3.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED |" in text
+    assert "page_3_review.md" in text


### PR DESCRIPTION
Reviews v0.1.2 page 3 and records the missing title-page release identifier. Boundary: page-3 audit metadata only; no theorem-level closure, no unrestricted Chronos-RR, no unrestricted H4.1/FGL, no P vs NP, and no Clay problem.