### PR TITLE
docs: review v0.1.2 page 4 roman-number extract

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -23,7 +23,7 @@ Does not prove:
 | 1 | `docs/page_audits/v0.1.2/page_1.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED | Source file for Preface page not yet located; see `docs/page_audits/v0.1.2/reviews/page_1_review.md`. |
 | 2 | `docs/page_audits/v0.1.2/page_2.txt` | NO_CHANGE | Page-number-only extract; see `docs/page_audits/v0.1.2/reviews/page_2_review.md`. |
 | 3 | `docs/page_audits/v0.1.2/page_3.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED | Title page lacks explicit `v0.1.2` release identifier; see `docs/page_audits/v0.1.2/reviews/page_3_review.md`. |
-| 4 | `docs/page_audits/v0.1.2/page_4.txt` | OPEN | Pending page review. |
+| 4 | `docs/page_audits/v0.1.2/page_4.txt` | NO_CHANGE | Roman-page-number-only extract; see `docs/page_audits/v0.1.2/reviews/page_4_review.md`. |
 | 5 | `docs/page_audits/v0.1.2/page_5.txt` | OPEN | Pending page review. |
 | 6 | `docs/page_audits/v0.1.2/page_6.txt` | OPEN | Pending page review. |
 | 7 | `docs/page_audits/v0.1.2/page_7.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_4_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_4_review.md
@@ -1,0 +1,25 @@
+# v0.1.2 Page 4 Review
+
+Page: 4
+Extract: `docs/page_audits/v0.1.2/page_4.txt`
+Status: `NO_CHANGE`
+
+## Finding
+
+Page 4 contains only the extracted roman page marker `ii`.
+
+There is no substantive mathematical, expository, metadata, or boundary text on this page.
+
+## Update
+
+No content update is required for page 4.
+
+## Boundary
+
+Does not prove:
+
+- unrestricted Chronos-RR;
+- unrestricted H4.1/FGL;
+- P vs NP;
+- any Clay problem;
+- any theorem-level closure not explicitly inherited from a buildable formal source repository.

--- a/tests/test_v012_page_04_roman_number_only_no_change.py
+++ b/tests/test_v012_page_04_roman_number_only_no_change.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_4_review.md"
+EXTRACT = ROOT / "docs/page_audits/v0.1.2/page_4.txt"
+
+def test_page_04_extract_is_roman_number_only():
+    assert EXTRACT.read_text(errors="ignore").strip() == "ii"
+
+def test_page_04_review_records_no_change():
+    assert REVIEW.exists()
+    text = REVIEW.read_text()
+    required = [
+        "Status: `NO_CHANGE`",
+        "Page 4 contains only the extracted roman page marker `ii`",
+        "No content update is required for page 4",
+        "Does not prove:",
+        "unrestricted Chronos-RR",
+        "unrestricted H4.1/FGL",
+        "P vs NP",
+        "any Clay problem",
+    ]
+    for token in required:
+        assert token in text, token
+
+def test_page_04_plan_row_records_no_change():
+    text = PLAN.read_text()
+    assert "| 4 | `docs/page_audits/v0.1.2/page_4.txt` | NO_CHANGE |" in text
+    assert "page_4_review.md" in text


### PR DESCRIPTION
Reviews v0.1.2 page 4 and records it as a roman-page-number-only/no-change page. Boundary: page-4 audit metadata only; no theorem-level closure, no unrestricted Chronos-RR, no unrestricted H4.1/FGL, no P vs NP, and no Clay problem.