### PR TITLE
docs: review v0.1.2 page 6 contents marker

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -25,7 +25,7 @@ Does not prove:
 | 3 | `docs/page_audits/v0.1.2/page_3.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED | Title page lacks explicit `v0.1.2` release identifier; see `docs/page_audits/v0.1.2/reviews/page_3_review.md`. |
 | 4 | `docs/page_audits/v0.1.2/page_4.txt` | NO_CHANGE | Roman-page-number-only extract; see `docs/page_audits/v0.1.2/reviews/page_4_review.md`. |
 | 5 | `docs/page_audits/v0.1.2/page_5.txt` | NO_CHANGE | Table-of-contents navigation only; see `docs/page_audits/v0.1.2/reviews/page_5_review.md`. |
-| 6 | `docs/page_audits/v0.1.2/page_6.txt` | OPEN | Pending page review. |
+| 6 | `docs/page_audits/v0.1.2/page_6.txt` | NO_CHANGE | Contents-continuation marker only; see `docs/page_audits/v0.1.2/reviews/page_6_review.md`. |
 | 7 | `docs/page_audits/v0.1.2/page_7.txt` | OPEN | Pending page review. |
 | 8 | `docs/page_audits/v0.1.2/page_8.txt` | OPEN | Pending page review. |
 | 9 | `docs/page_audits/v0.1.2/page_9.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_6_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_6_review.md
@@ -1,0 +1,25 @@
+# v0.1.2 Page 6 Review
+
+Page: 6
+Extract: `docs/page_audits/v0.1.2/page_6.txt`
+Status: `NO_CHANGE`
+
+## Finding
+
+Page 6 contains only the extracted continuation marker `iv CONTENTS`.
+
+There is no substantive mathematical, expository, metadata, or boundary text on this page.
+
+## Update
+
+No content update is required for page 6.
+
+## Boundary
+
+Does not prove:
+
+- unrestricted Chronos-RR;
+- unrestricted H4.1/FGL;
+- P vs NP;
+- any Clay problem;
+- any theorem-level closure not explicitly inherited from a buildable formal source repository.

--- a/tests/test_v012_page_06_contents_marker_no_change.py
+++ b/tests/test_v012_page_06_contents_marker_no_change.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_6_review.md"
+EXTRACT = ROOT / "docs/page_audits/v0.1.2/page_6.txt"
+
+def test_page_06_extract_is_contents_marker_only():
+    assert EXTRACT.read_text(errors="ignore").strip() == "iv CONTENTS"
+
+def test_page_06_review_records_no_change():
+    assert REVIEW.exists()
+    text = REVIEW.read_text()
+    required = [
+        "Status: `NO_CHANGE`",
+        "Page 6 contains only the extracted continuation marker `iv CONTENTS`",
+        "No content update is required for page 6",
+        "Does not prove:",
+        "unrestricted Chronos-RR",
+        "unrestricted H4.1/FGL",
+        "P vs NP",
+        "any Clay problem",
+    ]
+    for token in required:
+        assert token in text, token
+
+def test_page_06_plan_row_records_no_change():
+    text = PLAN.read_text()
+    assert "| 6 | `docs/page_audits/v0.1.2/page_6.txt` | NO_CHANGE |" in text
+    assert "page_6_review.md" in text


### PR DESCRIPTION
Reviews v0.1.2 page 6 and records it as a contents-continuation-marker/no-change page. Boundary: page-6 audit metadata only; no theorem-level closure, no unrestricted Chronos-RR, no unrestricted H4.1/FGL, no P vs NP, and no Clay problem.