### PR TITLE
docs: review v0.1.2 page 7 foundations context

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -26,7 +26,7 @@ Does not prove:
 | 4 | `docs/page_audits/v0.1.2/page_4.txt` | NO_CHANGE | Roman-page-number-only extract; see `docs/page_audits/v0.1.2/reviews/page_4_review.md`. |
 | 5 | `docs/page_audits/v0.1.2/page_5.txt` | NO_CHANGE | Table-of-contents navigation only; see `docs/page_audits/v0.1.2/reviews/page_5_review.md`. |
 | 6 | `docs/page_audits/v0.1.2/page_6.txt` | NO_CHANGE | Contents-continuation marker only; see `docs/page_audits/v0.1.2/reviews/page_6_review.md`. |
-| 7 | `docs/page_audits/v0.1.2/page_7.txt` | OPEN | Pending page review. |
+| 7 | `docs/page_audits/v0.1.2/page_7.txt` | MISSING_CONTEXT | First substantive foundations page; extracted capacity-bound formula appears incomplete; see `docs/page_audits/v0.1.2/reviews/page_7_review.md`. |
 | 8 | `docs/page_audits/v0.1.2/page_8.txt` | OPEN | Pending page review. |
 | 9 | `docs/page_audits/v0.1.2/page_9.txt` | OPEN | Pending page review. |
 | 10 | `docs/page_audits/v0.1.2/page_10.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_7_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_7_review.md
@@ -1,0 +1,38 @@
+# v0.1.2 Page 7 Review
+
+Page: 7
+Extract: `docs/page_audits/v0.1.2/page_7.txt`
+Status: `MISSING_CONTEXT`
+
+## Finding
+
+Page 7 begins Chapter 1, `Foundations`.
+
+The extracted page text includes:
+
+- `Transcript-Limited Refinement`
+- `Capacity Bound`
+- a tuple definition for a refinement system
+- a mutual-information capacity-bound expression beginning with `I(X;T`
+
+The extracted formula appears incomplete at the end of the page extract. Because this is the first substantive mathematical page, the page should not be marked `NO_CHANGE` from the extract alone.
+
+## Update
+
+No source text was modified in this step.
+
+This review records the missing context object for page 7.
+
+## Required Next Object
+
+Locate the source file for Chapter 1, then verify the complete capacity-bound statement against the PDF and source.
+
+## Boundary
+
+Does not prove:
+
+- unrestricted Chronos-RR;
+- unrestricted H4.1/FGL;
+- P vs NP;
+- any Clay problem;
+- any theorem-level closure not explicitly inherited from a buildable formal source repository.

--- a/tests/test_v012_page_07_foundations_missing_context.py
+++ b/tests/test_v012_page_07_foundations_missing_context.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_7_review.md"
+EXTRACT = ROOT / "docs/page_audits/v0.1.2/page_7.txt"
+
+def test_page_07_extract_is_substantive_foundations_page():
+    text = EXTRACT.read_text(errors="ignore")
+    required = [
+        "Chapter 1",
+        "Foundations",
+        "Transcript-Limited Refinement",
+        "Capacity Bound",
+        "I(X;",
+    ]
+    for token in required:
+        assert token in text, token
+
+def test_page_07_review_records_missing_context():
+    assert REVIEW.exists()
+    text = REVIEW.read_text()
+    required = [
+        "Status: `MISSING_CONTEXT`",
+        "first substantive mathematical page",
+        "extracted formula appears incomplete",
+        "Required Next Object",
+        "verify the complete capacity-bound statement",
+        "Does not prove:",
+        "unrestricted Chronos-RR",
+        "unrestricted H4.1/FGL",
+        "P vs NP",
+        "any Clay problem",
+    ]
+    for token in required:
+        assert token in text, token
+
+def test_page_07_plan_row_records_missing_context():
+    text = PLAN.read_text()
+    assert "| 7 | `docs/page_audits/v0.1.2/page_7.txt` | MISSING_CONTEXT |" in text
+    assert "page_7_review.md" in text


### PR DESCRIPTION
Reviews v0.1.2 page 7 and records the missing context object for the first substantive foundations page. Boundary: page-7 audit metadata only; no theorem-level closure, no unrestricted Chronos-RR, no unrestricted H4.1/FGL, no P vs NP, and no Clay problem.