### PR TITLE
docs: review v0.1.2 page 8 chapter marker

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -27,7 +27,7 @@ Does not prove:
 | 5 | `docs/page_audits/v0.1.2/page_5.txt` | NO_CHANGE | Table-of-contents navigation only; see `docs/page_audits/v0.1.2/reviews/page_5_review.md`. |
 | 6 | `docs/page_audits/v0.1.2/page_6.txt` | NO_CHANGE | Contents-continuation marker only; see `docs/page_audits/v0.1.2/reviews/page_6_review.md`. |
 | 7 | `docs/page_audits/v0.1.2/page_7.txt` | MISSING_CONTEXT | First substantive foundations page; extracted capacity-bound formula appears incomplete; see `docs/page_audits/v0.1.2/reviews/page_7_review.md`. |
-| 8 | `docs/page_audits/v0.1.2/page_8.txt` | OPEN | Pending page review. |
+| 8 | `docs/page_audits/v0.1.2/page_8.txt` | NO_CHANGE | Chapter-continuation marker only; see `docs/page_audits/v0.1.2/reviews/page_8_review.md`. |
 | 9 | `docs/page_audits/v0.1.2/page_9.txt` | OPEN | Pending page review. |
 | 10 | `docs/page_audits/v0.1.2/page_10.txt` | OPEN | Pending page review. |
 | 11 | `docs/page_audits/v0.1.2/page_11.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_8_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_8_review.md
@@ -1,0 +1,25 @@
+# v0.1.2 Page 8 Review
+
+Page: 8
+Extract: `docs/page_audits/v0.1.2/page_8.txt`
+Status: `NO_CHANGE`
+
+## Finding
+
+Page 8 contains only the extracted chapter continuation marker `2CHAPTER 1. FOUNDATIONS`.
+
+There is no substantive mathematical, expository, metadata, or boundary text on this page.
+
+## Update
+
+No content update is required for page 8.
+
+## Boundary
+
+Does not prove:
+
+- unrestricted Chronos-RR;
+- unrestricted H4.1/FGL;
+- P vs NP;
+- any Clay problem;
+- any theorem-level closure not explicitly inherited from a buildable formal source repository.

--- a/tests/test_v012_page_08_chapter_marker_no_change.py
+++ b/tests/test_v012_page_08_chapter_marker_no_change.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_8_review.md"
+EXTRACT = ROOT / "docs/page_audits/v0.1.2/page_8.txt"
+
+def test_page_08_extract_is_chapter_marker_only():
+    assert EXTRACT.read_text(errors="ignore").strip() == "2CHAPTER 1. FOUNDATIONS"
+
+def test_page_08_review_records_no_change():
+    assert REVIEW.exists()
+    text = REVIEW.read_text()
+    required = [
+        "Status: `NO_CHANGE`",
+        "Page 8 contains only the extracted chapter continuation marker",
+        "No content update is required for page 8",
+        "Does not prove:",
+        "unrestricted Chronos-RR",
+        "unrestricted H4.1/FGL",
+        "P vs NP",
+        "any Clay problem",
+    ]
+    for token in required:
+        assert token in text, token
+
+def test_page_08_plan_row_records_no_change():
+    text = PLAN.read_text()
+    assert "| 8 | `docs/page_audits/v0.1.2/page_8.txt` | NO_CHANGE |" in text
+    assert "page_8_review.md" in text


### PR DESCRIPTION
Reviews v0.1.2 page 8 and records it as a chapter-continuation-marker/no-change page. Boundary: page-8 audit metadata only; no theorem-level closure, no unrestricted Chronos-RR, no unrestricted H4.1/FGL, no P vs NP, and no Clay problem.