### PR TITLE
docs: add v0.1.2 page 7 capacity-bound source context

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -26,7 +26,7 @@ Does not prove:
 | 4 | `docs/page_audits/v0.1.2/page_4.txt` | NO_CHANGE | Roman-page-number-only extract; see `docs/page_audits/v0.1.2/reviews/page_4_review.md`. |
 | 5 | `docs/page_audits/v0.1.2/page_5.txt` | NO_CHANGE | Table-of-contents navigation only; see `docs/page_audits/v0.1.2/reviews/page_5_review.md`. |
 | 6 | `docs/page_audits/v0.1.2/page_6.txt` | NO_CHANGE | Contents-continuation marker only; see `docs/page_audits/v0.1.2/reviews/page_6_review.md`. |
-| 7 | `docs/page_audits/v0.1.2/page_7.txt` | BOUNDARY_CLARIFICATION | Added capacity-bound source context note; see `docs/page_audits/v0.1.2/reviews/page_7_source_patch.md`. |
+| 7 | `docs/page_audits/v0.1.2/page_7.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED | Source location identified but source patch reverted after LaTeX Build failure; see `docs/page_audits/v0.1.2/reviews/page_7_source_patch.md`. |
 | 8 | `docs/page_audits/v0.1.2/page_8.txt` | NO_CHANGE | Chapter-continuation marker only; see `docs/page_audits/v0.1.2/reviews/page_8_review.md`. |
 | 9 | `docs/page_audits/v0.1.2/page_9.txt` | OPEN | Pending page review. |
 | 10 | `docs/page_audits/v0.1.2/page_10.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -26,7 +26,7 @@ Does not prove:
 | 4 | `docs/page_audits/v0.1.2/page_4.txt` | NO_CHANGE | Roman-page-number-only extract; see `docs/page_audits/v0.1.2/reviews/page_4_review.md`. |
 | 5 | `docs/page_audits/v0.1.2/page_5.txt` | NO_CHANGE | Table-of-contents navigation only; see `docs/page_audits/v0.1.2/reviews/page_5_review.md`. |
 | 6 | `docs/page_audits/v0.1.2/page_6.txt` | NO_CHANGE | Contents-continuation marker only; see `docs/page_audits/v0.1.2/reviews/page_6_review.md`. |
-| 7 | `docs/page_audits/v0.1.2/page_7.txt` | MISSING_CONTEXT | First substantive foundations page; extracted capacity-bound formula appears incomplete; see `docs/page_audits/v0.1.2/reviews/page_7_review.md`. |
+| 7 | `docs/page_audits/v0.1.2/page_7.txt` | BOUNDARY_CLARIFICATION | Added capacity-bound source context note; see `docs/page_audits/v0.1.2/reviews/page_7_source_patch.md`. |
 | 8 | `docs/page_audits/v0.1.2/page_8.txt` | NO_CHANGE | Chapter-continuation marker only; see `docs/page_audits/v0.1.2/reviews/page_8_review.md`. |
 | 9 | `docs/page_audits/v0.1.2/page_9.txt` | OPEN | Pending page review. |
 | 10 | `docs/page_audits/v0.1.2/page_10.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_7_source_patch.md
+++ b/docs/page_audits/v0.1.2/reviews/page_7_source_patch.md
@@ -1,18 +1,19 @@
-# v0.1.2 Page 7 Source Patch
+# v0.1.2 Page 7 Source Patch Attempt
 
 Page: 7
 Extract: `docs/page_audits/v0.1.2/page_7.txt`
 Prior review: `docs/page_audits/v0.1.2/reviews/page_7_review.md`
-Status: `BOUNDARY_CLARIFICATION`
-Source patched: `journal/urf_core.tex`
+Status: `SOURCE_OR_RELEASE_METADATA_NEEDED`
 
-## Patch
+## Result
 
-Added a local context note at the page 7 capacity-bound source location.
+The page 7 capacity-bound source location was identified as `journal/urf_core.tex`, but the initial source-context edit caused the LaTeX Build workflow to fail.
 
-## Purpose
+The source edit was reverted in this PR to preserve a passing release/documentation state.
 
-The note clarifies that the capacity bound is an exposition-level organizing invariant unless backed by a buildable formal source repository artifact.
+## Required Next Object
+
+Add a LaTeX-build-safe source-context note for the page 7 capacity-bound section, verified by the LaTeX Build workflow.
 
 ## Boundary
 

--- a/docs/page_audits/v0.1.2/reviews/page_7_source_patch.md
+++ b/docs/page_audits/v0.1.2/reviews/page_7_source_patch.md
@@ -1,0 +1,25 @@
+# v0.1.2 Page 7 Source Patch
+
+Page: 7
+Extract: `docs/page_audits/v0.1.2/page_7.txt`
+Prior review: `docs/page_audits/v0.1.2/reviews/page_7_review.md`
+Status: `BOUNDARY_CLARIFICATION`
+Source patched: `journal/urf_core.tex`
+
+## Patch
+
+Added a local context note at the page 7 capacity-bound source location.
+
+## Purpose
+
+The note clarifies that the capacity bound is an exposition-level organizing invariant unless backed by a buildable formal source repository artifact.
+
+## Boundary
+
+Does not prove:
+
+- unrestricted Chronos-RR;
+- unrestricted H4.1/FGL;
+- P vs NP;
+- any Clay problem;
+- any theorem-level closure not explicitly inherited from a buildable formal source repository.

--- a/journal/urf_core.tex
+++ b/journal/urf_core.tex
@@ -40,7 +40,12 @@ x_0 \to x_1 \to \cdots \to x_t,
 \]
 \end{definition}
 
-\begin{definition}[Capacity Bound]
+\begin{definition}[Capacity Bound
+\paragraph{Context note.}
+The capacity bound on this page is an exposition-level organizing invariant for the textbook.
+It should be read as the local transcript-capacity obstruction guiding later formal surfaces, not as an independent proof of any unrestricted theorem.
+When a theorem-level statement is intended, the source of truth is the corresponding buildable formal repository artifact, including repository, commit or release, file path, theorem or artifact name, and status label.
+]
 Let $H:X\to\mathbb{R}_{\ge 0}$ be an entropy functional.  
 Assume there exists $C>0$ such that
 \[

--- a/journal/urf_core.tex
+++ b/journal/urf_core.tex
@@ -41,7 +41,8 @@ x_0 \to x_1 \to \cdots \to x_t,
 \end{definition}
 
 \begin{definition}[Capacity Bound
-\paragraph{Context note.}
+
+\noindent\textbf{Context note.}
 The capacity bound on this page is an exposition-level organizing invariant for the textbook.
 It should be read as the local transcript-capacity obstruction guiding later formal surfaces, not as an independent proof of any unrestricted theorem.
 When a theorem-level statement is intended, the source of truth is the corresponding buildable formal repository artifact, including repository, commit or release, file path, theorem or artifact name, and status label.

--- a/journal/urf_core.tex
+++ b/journal/urf_core.tex
@@ -40,13 +40,7 @@ x_0 \to x_1 \to \cdots \to x_t,
 \]
 \end{definition}
 
-\begin{definition}[Capacity Bound
-
-\noindent\textbf{Context note.}
-The capacity bound on this page is an exposition-level organizing invariant for the textbook.
-It should be read as the local transcript-capacity obstruction guiding later formal surfaces, not as an independent proof of any unrestricted theorem.
-When a theorem-level statement is intended, the source of truth is the corresponding buildable formal repository artifact, including repository, commit or release, file path, theorem or artifact name, and status label.
-]
+\begin{definition}[Capacity Bound]
 Let $H:X\to\mathbb{R}_{\ge 0}$ be an entropy functional.  
 Assume there exists $C>0$ such that
 \[

--- a/tests/test_v012_page_07_capacity_bound_source_patch.py
+++ b/tests/test_v012_page_07_capacity_bound_source_patch.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+PATCH = ROOT / "docs/page_audits/v0.1.2/reviews/page_7_source_patch.md"
+
+def test_page_07_source_patch_review_exists():
+    assert PATCH.exists()
+    text = PATCH.read_text()
+    required = [
+        "Status: `BOUNDARY_CLARIFICATION`",
+        "Source patched: `journal/urf_core.tex`",
+        "Added a local context note",
+        "exposition-level organizing invariant",
+        "buildable formal source repository artifact",
+        "Does not prove:",
+        "unrestricted Chronos-RR",
+        "unrestricted H4.1/FGL",
+        "P vs NP",
+        "any Clay problem",
+    ]
+    for token in required:
+        assert token in text, token
+
+def test_page_07_plan_row_records_source_patch():
+    text = PLAN.read_text()
+    assert "| 7 | `docs/page_audits/v0.1.2/page_7.txt` | BOUNDARY_CLARIFICATION |" in text
+    assert "page_7_source_patch.md" in text
+
+def test_page_07_source_contains_context_note():
+    text = PATCH.read_text()
+    marker = "Source patched: `"
+    start = text.index(marker) + len(marker)
+    end = text.index("`", start)
+    source = ROOT / text[start:end]
+    source_text = source.read_text(errors="ignore")
+    required = [
+        "The capacity bound on this page is an exposition-level organizing invariant for the textbook.",
+        "not as an independent proof of any unrestricted theorem",
+        "the source of truth is the corresponding buildable formal repository artifact",
+    ]
+    for token in required:
+        assert token in source_text, token

--- a/tests/test_v012_page_07_capacity_bound_source_patch.py
+++ b/tests/test_v012_page_07_capacity_bound_source_patch.py
@@ -4,15 +4,16 @@ ROOT = Path(__file__).resolve().parents[1]
 PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
 PATCH = ROOT / "docs/page_audits/v0.1.2/reviews/page_7_source_patch.md"
 
-def test_page_07_source_patch_review_exists():
+def test_page_07_source_patch_attempt_records_latex_blocker():
     assert PATCH.exists()
     text = PATCH.read_text()
     required = [
-        "Status: `BOUNDARY_CLARIFICATION`",
-        "Source patched: `journal/urf_core.tex`",
-        "Added a local context note",
-        "exposition-level organizing invariant",
-        "buildable formal source repository artifact",
+        "Status: `SOURCE_OR_RELEASE_METADATA_NEEDED`",
+        "source location was identified as `journal/urf_core.tex`",
+        "initial source-context edit caused the LaTeX Build workflow to fail",
+        "source edit was reverted",
+        "Required Next Object",
+        "LaTeX-build-safe source-context note",
         "Does not prove:",
         "unrestricted Chronos-RR",
         "unrestricted H4.1/FGL",
@@ -22,22 +23,7 @@ def test_page_07_source_patch_review_exists():
     for token in required:
         assert token in text, token
 
-def test_page_07_plan_row_records_source_patch():
+def test_page_07_plan_row_records_latex_blocker():
     text = PLAN.read_text()
-    assert "| 7 | `docs/page_audits/v0.1.2/page_7.txt` | BOUNDARY_CLARIFICATION |" in text
+    assert "| 7 | `docs/page_audits/v0.1.2/page_7.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED |" in text
     assert "page_7_source_patch.md" in text
-
-def test_page_07_source_contains_context_note():
-    text = PATCH.read_text()
-    marker = "Source patched: `"
-    start = text.index(marker) + len(marker)
-    end = text.index("`", start)
-    source = ROOT / text[start:end]
-    source_text = source.read_text(errors="ignore")
-    required = [
-        "The capacity bound on this page is an exposition-level organizing invariant for the textbook.",
-        "not as an independent proof of any unrestricted theorem",
-        "the source of truth is the corresponding buildable formal repository artifact",
-    ]
-    for token in required:
-        assert token in source_text, token

--- a/tests/test_v012_page_07_foundations_missing_context.py
+++ b/tests/test_v012_page_07_foundations_missing_context.py
@@ -35,7 +35,17 @@ def test_page_07_review_records_missing_context():
     for token in required:
         assert token in text, token
 
-def test_page_07_plan_row_records_missing_context():
+def test_page_07_initial_review_file_records_missing_context():
+    assert REVIEW.exists()
+    text = REVIEW.read_text()
+    assert "Status: `MISSING_CONTEXT`" in text
+    assert "page 7" in text.lower()
+
+def test_page_07_plan_row_is_reviewed_or_promoted():
     text = PLAN.read_text()
-    assert "| 7 | `docs/page_audits/v0.1.2/page_7.txt` | MISSING_CONTEXT |" in text
-    assert "page_7_review.md" in text
+    assert "| 7 | `docs/page_audits/v0.1.2/page_7.txt` |" in text
+    assert (
+        "| 7 | `docs/page_audits/v0.1.2/page_7.txt` | MISSING_CONTEXT |" in text
+        or "| 7 | `docs/page_audits/v0.1.2/page_7.txt` | BOUNDARY_CLARIFICATION |" in text
+        or "| 7 | `docs/page_audits/v0.1.2/page_7.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED |" in text
+    )


### PR DESCRIPTION
Updates the page 7 source-context follow-up and relaxes the original page-7 audit test so the plan row may be promoted from MISSING_CONTEXT after a source-context patch or source-location blocker is recorded. Boundary: page-7 documentation clarification only; no theorem-level closure, no unrestricted Chronos-RR, no unrestricted H4.1/FGL, no P vs NP, and no Clay problem.