### PR TITLE
docs: review v0.1.2 page 9 refinement locality

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -28,7 +28,7 @@ Does not prove:
 | 6 | `docs/page_audits/v0.1.2/page_6.txt` | NO_CHANGE | Contents-continuation marker only; see `docs/page_audits/v0.1.2/reviews/page_6_review.md`. |
 | 7 | `docs/page_audits/v0.1.2/page_7.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED | Source location identified but source patch reverted after LaTeX Build failure; see `docs/page_audits/v0.1.2/reviews/page_7_source_patch.md`. |
 | 8 | `docs/page_audits/v0.1.2/page_8.txt` | NO_CHANGE | Chapter-continuation marker only; see `docs/page_audits/v0.1.2/reviews/page_8_review.md`. |
-| 9 | `docs/page_audits/v0.1.2/page_9.txt` | OPEN | Pending page review. |
+| 9 | `docs/page_audits/v0.1.2/page_9.txt` | BOUNDARY_CLARIFICATION | Chapter 2 introduces refinement/locality normalization and capacity invariant; see `docs/page_audits/v0.1.2/reviews/page_9_review.md`. |
 | 10 | `docs/page_audits/v0.1.2/page_10.txt` | OPEN | Pending page review. |
 | 11 | `docs/page_audits/v0.1.2/page_11.txt` | OPEN | Pending page review. |
 | 12 | `docs/page_audits/v0.1.2/page_12.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_9_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_9_review.md
@@ -1,0 +1,41 @@
+# v0.1.2 Page 9 Review
+
+Page: 9
+Extract: `docs/page_audits/v0.1.2/page_9.txt`
+Status: `BOUNDARY_CLARIFICATION`
+
+## Finding
+
+Page 9 begins Chapter 2, `Refinement and Locality`.
+
+The extracted page text includes:
+
+- bounded transcript capacity;
+- admissible refinement operators;
+- locality constraints;
+- normalization principle;
+- polynomial-time algorithms;
+- bounded-width refinement sequences;
+- `Information Gain per Step≤C`.
+
+This is substantive mathematical exposition.
+
+## Update
+
+No source text was modified in this step.
+
+This review records that the page needs boundary discipline because it bridges definitions to structural lemmas and mentions algorithmic normalization.
+
+## Required Next Object
+
+Locate the Chapter 2 source file and verify that the normalization statement is framed as exposition unless backed by a buildable formal source repository artifact.
+
+## Boundary
+
+Does not prove:
+
+- unrestricted Chronos-RR;
+- unrestricted H4.1/FGL;
+- P vs NP;
+- any Clay problem;
+- any theorem-level closure not explicitly inherited from a buildable formal source repository.

--- a/tests/test_v012_page_09_refinement_locality_boundary.py
+++ b/tests/test_v012_page_09_refinement_locality_boundary.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_9_review.md"
+EXTRACT = ROOT / "docs/page_audits/v0.1.2/page_9.txt"
+
+def test_page_09_extract_is_substantive_refinement_locality_page():
+    text = EXTRACT.read_text(errors="ignore")
+    required = [
+        "Chapter 2",
+        "Refinement and Locality",
+        "bounded transcript capacity",
+        "admissible refinement operators",
+        "locality constraints",
+        "normalization principle",
+        "polynomial-time algorithms",
+        "bounded-width refinement sequences",
+        "Information Gain per Step",
+    ]
+    for token in required:
+        assert token in text, token
+
+def test_page_09_review_records_boundary_clarification():
+    assert REVIEW.exists()
+    text = REVIEW.read_text()
+    required = [
+        "Status: `BOUNDARY_CLARIFICATION`",
+        "substantive mathematical exposition",
+        "algorithmic normalization",
+        "Required Next Object",
+        "buildable formal source repository artifact",
+        "Does not prove:",
+        "unrestricted Chronos-RR",
+        "unrestricted H4.1/FGL",
+        "P vs NP",
+        "any Clay problem",
+    ]
+    for token in required:
+        assert token in text, token
+
+def test_page_09_plan_row_records_boundary_clarification():
+    text = PLAN.read_text()
+    assert "| 9 | `docs/page_audits/v0.1.2/page_9.txt` | BOUNDARY_CLARIFICATION |" in text
+    assert "page_9_review.md" in text


### PR DESCRIPTION
Reviews v0.1.2 page 9 and records boundary clarification for the Chapter 2 refinement/locality normalization text. Boundary: page-9 audit metadata only; no theorem-level closure, no unrestricted Chronos-RR, no unrestricted H4.1/FGL, no P vs NP, and no Clay problem.