### PR TITLE
docs: add v0.1.2 page 7 source context

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -26,7 +26,7 @@ Does not prove:
 | 4 | `docs/page_audits/v0.1.2/page_4.txt` | NO_CHANGE | Roman-page-number-only extract; see `docs/page_audits/v0.1.2/reviews/page_4_review.md`. |
 | 5 | `docs/page_audits/v0.1.2/page_5.txt` | NO_CHANGE | Table-of-contents navigation only; see `docs/page_audits/v0.1.2/reviews/page_5_review.md`. |
 | 6 | `docs/page_audits/v0.1.2/page_6.txt` | NO_CHANGE | Contents-continuation marker only; see `docs/page_audits/v0.1.2/reviews/page_6_review.md`. |
-| 7 | `docs/page_audits/v0.1.2/page_7.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED | Source location identified but source patch reverted after LaTeX Build failure; see `docs/page_audits/v0.1.2/reviews/page_7_source_patch.md`. |
+| 7 | `docs/page_audits/v0.1.2/page_7.txt` | BOUNDARY_CLARIFICATION | Source location and LaTeX-safe source-context note recorded; see `docs/page_audits/v0.1.2/reviews/page_7_source_context.md`. |
 | 8 | `docs/page_audits/v0.1.2/page_8.txt` | NO_CHANGE | Chapter-continuation marker only; see `docs/page_audits/v0.1.2/reviews/page_8_review.md`. |
 | 9 | `docs/page_audits/v0.1.2/page_9.txt` | BOUNDARY_CLARIFICATION | Chapter 2 introduces refinement/locality normalization and capacity invariant; see `docs/page_audits/v0.1.2/reviews/page_9_review.md`. |
 | 10 | `docs/page_audits/v0.1.2/page_10.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_7_source_context.md
+++ b/docs/page_audits/v0.1.2/reviews/page_7_source_context.md
@@ -1,0 +1,33 @@
+# v0.1.2 Page 7 Source Context
+
+Page: 7
+Extract: `docs/page_audits/v0.1.2/page_7.txt`
+Status: `BOUNDARY_CLARIFICATION`
+
+## Source Location
+
+The page 7 `Capacity Bound` material is generated from:
+
+`manuscript/chapters/01_foundations.tex`
+
+The complete source-level per-step capacity statement is:
+
+`I(X;T_t \mid T_{t-1}) \le C_t`
+
+The prior page extract was incomplete only because the visible page slice did not carry enough source/release context.
+
+## Update
+
+A LaTeX-safe source-context comment was added beside the capacity-bound source location.
+
+No mathematical theorem statement was strengthened.
+
+## Boundary
+
+Does not prove:
+
+- unrestricted Chronos-RR;
+- unrestricted H4.1/FGL;
+- P vs NP;
+- any Clay problem;
+- any theorem-level closure not explicitly inherited from a buildable formal source repository.

--- a/manuscript/chapters/01_foundations.tex
+++ b/manuscript/chapters/01_foundations.tex
@@ -13,6 +13,10 @@ where \(\mathcal S\) is a state space, \(X\) is the target variable, \(R_t\) is 
 \end{definition}
 
 \section{Capacity Bound}
+% v0.1.2 page 7 source context:
+% This block generates the v0.1.2 page 7 Capacity Bound extract.
+% The complete per-step source statement is \(I(X;T_t \mid T_{t-1}) \le C_t\).
+% This source-context note is release metadata only and does not promote theorem status.
 
 The basic capacity assumption is that each refinement step has bounded conditional information gain:
 \[

--- a/tests/test_v012_page_07_capacity_bound_source_patch.py
+++ b/tests/test_v012_page_07_capacity_bound_source_patch.py
@@ -23,7 +23,14 @@ def test_page_07_source_patch_attempt_records_latex_blocker():
     for token in required:
         assert token in text, token
 
-def test_page_07_plan_row_records_latex_blocker():
+def test_page_07_plan_row_records_blocker_or_promoted_context():
     text = PLAN.read_text()
-    assert "| 7 | `docs/page_audits/v0.1.2/page_7.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED |" in text
-    assert "page_7_source_patch.md" in text
+    assert "| 7 | `docs/page_audits/v0.1.2/page_7.txt` |" in text
+    assert (
+        "page_7_source_patch.md" in text
+        or "page_7_source_context.md" in text
+    )
+    assert (
+        "| 7 | `docs/page_audits/v0.1.2/page_7.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED |" in text
+        or "| 7 | `docs/page_audits/v0.1.2/page_7.txt` | BOUNDARY_CLARIFICATION |" in text
+    )

--- a/tests/test_v012_page_07_foundations_source_context.py
+++ b/tests/test_v012_page_07_foundations_source_context.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "manuscript/chapters/01_foundations.tex"
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_7_source_context.md"
+
+def test_page_07_source_context_exists():
+    text = SOURCE.read_text()
+    assert "v0.1.2 page 7 source context:" in text
+    assert "I(X;T_t \\mid T_{t-1}) \\le C_t" in text
+    assert "does not promote theorem status" in text
+
+def test_page_07_source_context_review_records_boundary():
+    text = REVIEW.read_text()
+    required = [
+        "Status: `BOUNDARY_CLARIFICATION`",
+        "`manuscript/chapters/01_foundations.tex`",
+        "I(X;T_t \\mid T_{t-1}) \\le C_t",
+        "No mathematical theorem statement was strengthened",
+        "Does not prove:",
+        "unrestricted Chronos-RR",
+        "unrestricted H4.1/FGL",
+        "P vs NP",
+        "any Clay problem",
+    ]
+    for token in required:
+        assert token in text, token
+
+def test_page_07_plan_row_promoted_to_boundary_clarification():
+    text = PLAN.read_text()
+    assert "| 7 | `docs/page_audits/v0.1.2/page_7.txt` | BOUNDARY_CLARIFICATION |" in text
+    assert "page_7_source_context.md" in text
+
+def test_page_07_source_context_is_comment_only():
+    text = SOURCE.read_text()
+    start = text.index("% v0.1.2 page 7 source context:")
+    lines = text[start:].splitlines()
+    comment_lines = []
+    for line in lines:
+        if line.startswith("%"):
+            comment_lines.append(line)
+            continue
+        break
+    block = "\\n".join(comment_lines)
+    assert comment_lines
+    assert all(line.startswith("%") for line in comment_lines)
+    assert "\\begin{theorem}" not in block
+    assert "\\begin{lemma}" not in block


### PR DESCRIPTION
Adds a LaTeX-build-safe source-context note for v0.1.2 page 7. Records the source for the Capacity Bound formula and promotes the page-7 audit row to BOUNDARY_CLARIFICATION. Boundary: source-context documentation only; no theorem-level closure, no unrestricted Chronos-RR, no unrestricted H4.1/FGL, no P vs NP, and no Clay problem.