### PR TITLE
docs: add v0.1.2 page 1 source context

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -20,7 +20,7 @@ Does not prove:
 
 | Page | Extract | Status | Needed update |
 |---:|---|---|---|
-| 1 | `docs/page_audits/v0.1.2/page_1.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED | Source file for Preface page not yet located; see `docs/page_audits/v0.1.2/reviews/page_1_review.md`. |
+| 1 | `docs/page_audits/v0.1.2/page_1.txt` | BOUNDARY_CLARIFICATION | Source location and LaTeX-safe source-context note recorded; see `docs/page_audits/v0.1.2/reviews/page_1_source_context.md`. |
 | 2 | `docs/page_audits/v0.1.2/page_2.txt` | NO_CHANGE | Page-number-only extract; see `docs/page_audits/v0.1.2/reviews/page_2_review.md`. |
 | 3 | `docs/page_audits/v0.1.2/page_3.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED | Title page lacks explicit `v0.1.2` release identifier; see `docs/page_audits/v0.1.2/reviews/page_3_review.md`. |
 | 4 | `docs/page_audits/v0.1.2/page_4.txt` | NO_CHANGE | Roman-page-number-only extract; see `docs/page_audits/v0.1.2/reviews/page_4_review.md`. |

--- a/docs/page_audits/v0.1.2/reviews/page_1_source_context.md
+++ b/docs/page_audits/v0.1.2/reviews/page_1_source_context.md
@@ -1,0 +1,40 @@
+# v0.1.2 Page 1 Source Context
+
+Page: 1
+Extract: `docs/page_audits/v0.1.2/page_1.txt`
+Prior review: `docs/page_audits/v0.1.2/reviews/page_1_review.md`
+Status: `BOUNDARY_CLARIFICATION`
+
+## Source Location
+
+The page 1 Preface/front-matter material is generated from:
+
+`manuscript/chapters/00_preface.tex`
+
+## Source Search Result
+
+The source was selected by page-text overlap against repository LaTeX files.
+
+Top candidates:
+
+- score 51: `manuscript/chapters/00_preface.tex`
+- score 45: `tex/chapters/00_orientation_legacy.tex`
+- score 45: `tex/chapters/legacy_merge/00_orientation.tex`
+- score 45: `chapters/00_orientation.tex`
+- score 39: `manuscript/main.tex`
+
+## Update
+
+A LaTeX-safe source-context comment was added beside the source location.
+
+No mathematical theorem statement was strengthened.
+
+## Boundary
+
+Does not prove:
+
+- unrestricted Chronos-RR;
+- unrestricted H4.1/FGL;
+- P vs NP;
+- any Clay problem;
+- any theorem-level closure not explicitly inherited from a buildable formal source repository.

--- a/manuscript/chapters/00_preface.tex
+++ b/manuscript/chapters/00_preface.tex
@@ -1,3 +1,6 @@
+% v0.1.2 page 1 source context:
+% This block identifies the source file for the v0.1.2 page 1 Preface/front-matter extract.
+% This source-context note is release metadata only and does not promote theorem status.
 \chapter*{Preface}
 \addcontentsline{toc}{chapter}{Preface}
 

--- a/tests/test_v012_page_01_preface_source_context.py
+++ b/tests/test_v012_page_01_preface_source_context.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "manuscript/chapters/00_preface.tex"
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_1_source_context.md"
+
+def test_page_01_source_context_exists():
+    text = SOURCE.read_text()
+    assert "v0.1.2 page 1 source context:" in text
+    assert "release metadata only" in text
+    assert "does not promote theorem status" in text
+
+def test_page_01_review_records_source_and_boundary():
+    text = REVIEW.read_text()
+    required = [
+        "Status: `BOUNDARY_CLARIFICATION`",
+        "`manuscript/chapters/00_preface.tex`",
+        "page-text overlap",
+        "No mathematical theorem statement was strengthened",
+        "Does not prove:",
+        "unrestricted Chronos-RR",
+        "unrestricted H4.1/FGL",
+        "P vs NP",
+        "any Clay problem",
+    ]
+    for token in required:
+        assert token in text, token
+
+def test_page_01_plan_row_promoted_to_boundary_clarification():
+    text = PLAN.read_text()
+    assert "| 1 | `docs/page_audits/v0.1.2/page_1.txt` | BOUNDARY_CLARIFICATION |" in text
+    assert "page_1_source_context.md" in text
+
+def test_page_01_source_context_is_comment_only():
+    text = SOURCE.read_text()
+    start = text.index("% v0.1.2 page 1 source context:")
+    lines = text[start:].splitlines()
+    comment_lines = []
+    for line in lines:
+        if line.startswith("%"):
+            comment_lines.append(line)
+            continue
+        break
+    block = "\n".join(comment_lines)
+    assert comment_lines
+    assert all(line.startswith("%") for line in comment_lines)
+    assert "\\begin{theorem}" not in block
+    assert "\\begin{lemma}" not in block

--- a/tests/test_v012_page_01_source_location_gap.py
+++ b/tests/test_v012_page_01_source_location_gap.py
@@ -22,10 +22,17 @@ def test_page_01_review_records_source_location_gap():
     for token in required:
         assert token in text, token
 
-def test_page_01_plan_row_records_source_location_gap():
+def test_page_01_plan_row_records_source_location_gap_or_context_closure():
     text = PLAN.read_text()
-    assert "| 1 | `docs/page_audits/v0.1.2/page_1.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED |" in text
-    assert "page_1_review.md" in text
+    assert "| 1 | `docs/page_audits/v0.1.2/page_1.txt` |" in text
+    assert (
+        "| 1 | `docs/page_audits/v0.1.2/page_1.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED |" in text
+        or "| 1 | `docs/page_audits/v0.1.2/page_1.txt` | BOUNDARY_CLARIFICATION |" in text
+    )
+    assert (
+        "page_1_review.md" in text
+        or "page_1_source_context.md" in text
+    )
 
 def test_page_01_extract_contains_preface_thesis():
     text = EXTRACT.read_text(errors="ignore")


### PR DESCRIPTION
Adds a LaTeX-build-safe source-context note for v0.1.2 page 1. Records the located Preface/front-matter source and promotes the page-1 audit row to BOUNDARY_CLARIFICATION. Boundary: source-context documentation only; no theorem-level closure, no unrestricted Chronos-RR, no unrestricted H4.1/FGL, no P vs NP, and no Clay problem.