### PR TITLE
docs: add v0.1.2 page 3 release identifier

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -22,7 +22,7 @@ Does not prove:
 |---:|---|---|---|
 | 1 | `docs/page_audits/v0.1.2/page_1.txt` | BOUNDARY_CLARIFICATION | Source location and LaTeX-safe source-context note recorded; see `docs/page_audits/v0.1.2/reviews/page_1_source_context.md`. |
 | 2 | `docs/page_audits/v0.1.2/page_2.txt` | NO_CHANGE | Page-number-only extract; see `docs/page_audits/v0.1.2/reviews/page_2_review.md`. |
-| 3 | `docs/page_audits/v0.1.2/page_3.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED | Title page lacks explicit `v0.1.2` release identifier; see `docs/page_audits/v0.1.2/reviews/page_3_review.md`. |
+| 3 | `docs/page_audits/v0.1.2/page_3.txt` | BOUNDARY_CLARIFICATION | Title-page release identifier added; see `docs/page_audits/v0.1.2/reviews/page_3_release_identifier.md`. |
 | 4 | `docs/page_audits/v0.1.2/page_4.txt` | NO_CHANGE | Roman-page-number-only extract; see `docs/page_audits/v0.1.2/reviews/page_4_review.md`. |
 | 5 | `docs/page_audits/v0.1.2/page_5.txt` | NO_CHANGE | Table-of-contents navigation only; see `docs/page_audits/v0.1.2/reviews/page_5_review.md`. |
 | 6 | `docs/page_audits/v0.1.2/page_6.txt` | NO_CHANGE | Contents-continuation marker only; see `docs/page_audits/v0.1.2/reviews/page_6_review.md`. |

--- a/docs/page_audits/v0.1.2/reviews/page_3_release_identifier.md
+++ b/docs/page_audits/v0.1.2/reviews/page_3_release_identifier.md
@@ -1,0 +1,30 @@
+# v0.1.2 Page 3 Release Identifier
+
+Page: 3
+Extract: `docs/page_audits/v0.1.2/page_3.txt`
+Prior review: `docs/page_audits/v0.1.2/reviews/page_3_review.md`
+Status: `BOUNDARY_CLARIFICATION`
+
+## Source Location
+
+The page 3 title-page material is generated from:
+
+`manuscript/main.tex`
+
+## Update
+
+The weakest release identifier was added to the title page source:
+
+`Release: v0.1.2`
+
+No mathematical theorem statement was strengthened.
+
+## Boundary
+
+Does not prove:
+
+- unrestricted Chronos-RR;
+- unrestricted H4.1/FGL;
+- P vs NP;
+- any Clay problem;
+- any theorem-level closure not explicitly inherited from a buildable formal source repository.

--- a/manuscript/main.tex
+++ b/manuscript/main.tex
@@ -52,7 +52,7 @@
 % -------------------------------------------------
 \title{Unified Rigidity Framework Textbook\\ Capacity, Locality, and Terminal Obstructions}
 \author{Inacio Vasquez}
-\date{\today}
+\date{\today\\Release: v0.1.2}
 
 % -------------------------------------------------
 % Document Start

--- a/tests/test_v012_page_03_release_identifier.py
+++ b/tests/test_v012_page_03_release_identifier.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "manuscript/main.tex"
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_3_release_identifier.md"
+
+def test_page_03_title_source_contains_release_identifier():
+    text = SOURCE.read_text()
+    assert "Unified Rigidity Framework Textbook" in text
+    assert "Release: v0.1.2" in text
+
+def test_page_03_release_identifier_review_records_boundary():
+    text = REVIEW.read_text()
+    required = [
+        "Status: `BOUNDARY_CLARIFICATION`",
+        "`manuscript/main.tex`",
+        "Release: v0.1.2",
+        "No mathematical theorem statement was strengthened",
+        "Does not prove:",
+        "unrestricted Chronos-RR",
+        "unrestricted H4.1/FGL",
+        "P vs NP",
+        "any Clay problem",
+    ]
+    for token in required:
+        assert token in text, token
+
+def test_page_03_plan_row_promoted_to_boundary_clarification():
+    text = PLAN.read_text()
+    assert "| 3 | `docs/page_audits/v0.1.2/page_3.txt` | BOUNDARY_CLARIFICATION |" in text
+    assert "page_3_release_identifier.md" in text

--- a/tests/test_v012_page_03_title_release_metadata.py
+++ b/tests/test_v012_page_03_title_release_metadata.py
@@ -33,7 +33,14 @@ def test_page_03_review_records_release_metadata_gap():
     for token in required:
         assert token in text, token
 
-def test_page_03_plan_row_records_release_metadata_gap():
+def test_page_03_plan_row_records_release_metadata_gap_or_closure():
     text = PLAN.read_text()
-    assert "| 3 | `docs/page_audits/v0.1.2/page_3.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED |" in text
-    assert "page_3_review.md" in text
+    assert "| 3 | `docs/page_audits/v0.1.2/page_3.txt` |" in text
+    assert (
+        "| 3 | `docs/page_audits/v0.1.2/page_3.txt` | SOURCE_OR_RELEASE_METADATA_NEEDED |" in text
+        or "| 3 | `docs/page_audits/v0.1.2/page_3.txt` | BOUNDARY_CLARIFICATION |" in text
+    )
+    assert (
+        "page_3_review.md" in text
+        or "page_3_release_identifier.md" in text
+    )


### PR DESCRIPTION
Adds the weakest visible release identifier to the v0.1.2 title-page source and promotes the page-3 audit row to BOUNDARY_CLARIFICATION. Boundary: release metadata only; no theorem-level closure, no unrestricted Chronos-RR, no unrestricted H4.1/FGL, no P vs NP, and no Clay problem.