### PR TITLE
docs: review v0.1.2 page 10 refinement locality

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -29,7 +29,7 @@ Does not prove:
 | 7 | `docs/page_audits/v0.1.2/page_7.txt` | BOUNDARY_CLARIFICATION | Source location and LaTeX-safe source-context note recorded; see `docs/page_audits/v0.1.2/reviews/page_7_source_context.md`. |
 | 8 | `docs/page_audits/v0.1.2/page_8.txt` | NO_CHANGE | Chapter-continuation marker only; see `docs/page_audits/v0.1.2/reviews/page_8_review.md`. |
 | 9 | `docs/page_audits/v0.1.2/page_9.txt` | BOUNDARY_CLARIFICATION | Chapter 2 introduces refinement/locality normalization and capacity invariant; see `docs/page_audits/v0.1.2/reviews/page_9_review.md`. |
-| 10 | `docs/page_audits/v0.1.2/page_10.txt` | OPEN | Pending page review. |
+| 10 | `docs/page_audits/v0.1.2/page_10.txt` | NO_CHANGE | Chapter-opening page reviewed; see `docs/page_audits/v0.1.2/reviews/page_10_review.md`. |
 | 11 | `docs/page_audits/v0.1.2/page_11.txt` | OPEN | Pending page review. |
 | 12 | `docs/page_audits/v0.1.2/page_12.txt` | OPEN | Pending page review. |
 | 13 | `docs/page_audits/v0.1.2/page_13.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_10_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_10_review.md
@@ -1,0 +1,35 @@
+# v0.1.2 Page 10 Review
+
+Page: 10
+Extract: `docs/page_audits/v0.1.2/page_10.txt`
+Status: `NO_CHANGE`
+
+## Finding
+
+Page 10 is a chapter-opening page for:
+
+`CHAPTER 2. REFINEMENT AND LOCALITY`
+
+The extracted page contains only the chapter heading/front-matter transition.
+
+## Source Location
+
+The chapter heading is generated from:
+
+`manuscript/chapters/02_refinement_locality.tex`
+
+## Update
+
+No PDF source text was modified.
+
+No release metadata or mathematical clarification is required for this page.
+
+## Boundary
+
+Does not prove:
+
+- unrestricted Chronos-RR;
+- unrestricted H4.1/FGL;
+- P vs NP;
+- any Clay problem;
+- any theorem-level closure not explicitly inherited from a buildable formal source repository.

--- a/tests/test_v012_page_10_refinement_locality_review.py
+++ b/tests/test_v012_page_10_refinement_locality_review.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = ROOT / "docs/page_audits/v0.1.2/page_10.txt"
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_10_review.md"
+SOURCE = ROOT / "manuscript/chapters/02_refinement_locality.tex"
+
+def test_page_10_extract_is_chapter_opening():
+    text = PAGE.read_text().upper()
+    assert "CHAPTER 2" in text
+    assert "REFINEMENT AND LOCALITY" in text
+
+def test_page_10_review_records_no_change_boundary():
+    text = REVIEW.read_text()
+    required = [
+        "Status: `NO_CHANGE`",
+        "CHAPTER 2. REFINEMENT AND LOCALITY",
+        "`manuscript/chapters/02_refinement_locality.tex`",
+        "No PDF source text was modified",
+        "No release metadata or mathematical clarification is required",
+        "Does not prove:",
+        "unrestricted Chronos-RR",
+        "unrestricted H4.1/FGL",
+        "P vs NP",
+        "any Clay problem",
+    ]
+    for token in required:
+        assert token in text, token
+
+def test_page_10_plan_row_marked_no_change():
+    text = PLAN.read_text()
+    assert "| 10 | `docs/page_audits/v0.1.2/page_10.txt` | NO_CHANGE |" in text
+    assert "page_10_review.md" in text
+
+def test_page_10_source_contains_refinement_locality_title():
+    text = SOURCE.read_text()
+    assert "Refinement and Locality" in text or "REFINEMENT AND LOCALITY" in text


### PR DESCRIPTION
Reviews v0.1.2 page 10 as the Chapter 2 Refinement and Locality opening page and marks it NO_CHANGE. Boundary: page-audit review only; no theorem-level closure, no unrestricted Chronos-RR, no unrestricted H4.1/FGL, no P vs NP, and no Clay problem.