### PR TITLE
docs: add quantum adapter amplification case study

### DIFF
--- a/docs/case_studies/quantum_adapter_invariant_bounded_amplification_2026_05_26.md
+++ b/docs/case_studies/quantum_adapter_invariant_bounded_amplification_2026_05_26.md
@@ -1,0 +1,43 @@
+# Quantum Adapter Case Study: Invariant-Bounded Amplification
+
+Status: `EXTERNAL_PATTERN_EVIDENCE_ONLY`
+
+Date recorded: 2026-05-26
+
+External object:
+
+- Live Science report: Scientists trained an AI model using an IBM quantum computer and it answered questions correctly that the base model could not.
+- Reported technical surface: frozen Llama 3.1 8B base model with a small quantum adapter executed through IBM quantum hardware.
+- Reported performance surface: approximately 6,000 added parameters and a reported 1.4% perplexity improvement.
+
+URF / IBPA reading:
+
+This case is consistent with the invariant-bounded performance amplification pattern:
+
+small structured refinement
+-> constrained nonclassical transformation channel
+-> measurable behavior change
+
+The relevant feature is not raw parameter scaling. The relevant feature is that a small structured adapter changes the admissible transformation space available to the model.
+
+Boundary:
+
+This record does not prove:
+
+- URF;
+- Chronos-RR;
+- H4.1/FGL;
+- P vs NP;
+- any Clay problem;
+- quantum advantage;
+- DFM-MKC;
+- invariant-bounded performance amplification as a theorem;
+- any claim that quantum adapters outperform all classical adapters.
+
+Classification:
+
+EXTERNAL_PATTERN_EVIDENCE_ONLY
+
+Use:
+
+This note may be cited only as an external case-study pattern consistent with invariant-bounded amplification. It is not theorem evidence and must not be promoted to a proof claim.

--- a/tests/test_quantum_adapter_iba_case_study.py
+++ b/tests/test_quantum_adapter_iba_case_study.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+DOC = Path("docs/case_studies/quantum_adapter_invariant_bounded_amplification_2026_05_26.md")
+
+REQUIRED = [
+    "EXTERNAL_PATTERN_EVIDENCE_ONLY",
+    "invariant-bounded performance amplification",
+    "small structured refinement",
+    "constrained nonclassical transformation channel",
+    "measurable behavior change",
+    "not raw parameter scaling",
+    "does not prove",
+    "URF",
+    "Chronos-RR",
+    "H4.1/FGL",
+    "P vs NP",
+    "any Clay problem",
+    "quantum advantage",
+    "DFM-MKC",
+    "not theorem evidence",
+]
+
+FORBIDDEN = [
+    "proves URF",
+    "proves Chronos-RR",
+    "proves H4.1",
+    "proves P vs NP",
+    "proves quantum advantage",
+    "solves any Clay problem",
+    "DFM-MKC validation",
+    "unrestricted theorem closure",
+]
+
+
+def test_quantum_adapter_case_study_boundary_tokens():
+    text = DOC.read_text()
+    for token in REQUIRED:
+        assert token in text, token
+
+
+def test_quantum_adapter_case_study_no_forbidden_promotions():
+    text = DOC.read_text()
+    for token in FORBIDDEN:
+        assert token not in text, token


### PR DESCRIPTION
Adds an external-pattern case study for the reported IBM quantum-adapter LLM result, classified strictly as EXTERNAL_PATTERN_EVIDENCE_ONLY. Boundary: case-study note only; no URF proof, no IBPA theorem validation, no Chronos-RR, no H4.1/FGL, no P vs NP, no Clay problem, no DFM-MKC validation, and no quantum-advantage claim.