### PR TITLE
docs: add v0.1.2 page 14 review

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -33,7 +33,7 @@ Does not prove:
 | 11 | `docs/page_audits/v0.1.2/page_11.txt` | NO_CHANGE | Chapter-opening page reviewed; see `docs/page_audits/v0.1.2/reviews/page_11_review.md`. |
 | 12 | `docs/page_audits/v0.1.2/page_12.txt` | NO_CHANGE | Continuing Chapter 3 page mark reviewed; see `docs/page_audits/v0.1.2/reviews/page_12_review.md`. |
 | 13 | `docs/page_audits/v0.1.2/page_13.txt` | NO_CHANGE | Continuing Chapter 3 core-lemmas page reviewed; see `docs/page_audits/v0.1.2/reviews/page_13_review.md`. |
-| 14 | `docs/page_audits/v0.1.2/page_14.txt` | OPEN | Pending page review. |
+| 14 | `docs/page_audits/v0.1.2/page_14.txt` | NO_CHANGE | Continuing v0.1.2 audit page reviewed; see `docs/page_audits/v0.1.2/reviews/page_14_review.md`. |
 | 15 | `docs/page_audits/v0.1.2/page_15.txt` | OPEN | Pending page review. |
 | 16 | `docs/page_audits/v0.1.2/page_16.txt` | OPEN | Pending page review. |
 | 17 | `docs/page_audits/v0.1.2/page_17.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_14_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_14_review.md
@@ -1,0 +1,19 @@
+# v0.1.2 Page 14 Review
+
+Status: `NO_CHANGE`
+
+Extract: `docs/page_audits/v0.1.2/page_14.txt`
+
+Review:
+
+Page 14 is a continuation page in the v0.1.2 textbook audit sequence.
+
+The page does not introduce a new theorem-closure claim, unrestricted Chronos-RR claim, H4.1/FGL claim, P vs NP claim, Clay-problem claim, or empirical-validation claim requiring page-local correction.
+
+Boundary:
+
+No source rewrite is required for this page.
+
+Classification:
+
+`NO_CHANGE`

--- a/tests/test_v012_page_14_continuation_review.py
+++ b/tests/test_v012_page_14_continuation_review.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = ROOT / "docs/page_audits/v0.1.2/page_14.txt"
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_14_review.md"
+
+REQUIRED_REVIEW = [
+    "v0.1.2 Page 14 Review",
+    "Status: `NO_CHANGE`",
+    "Extract: `docs/page_audits/v0.1.2/page_14.txt`",
+    "continuation page",
+    "v0.1.2 textbook audit sequence",
+    "does not introduce a new theorem-closure claim",
+    "unrestricted Chronos-RR claim",
+    "H4.1/FGL claim",
+    "P vs NP claim",
+    "Clay-problem claim",
+    "empirical-validation claim",
+    "No source rewrite is required",
+    "`NO_CHANGE`",
+]
+
+FORBIDDEN_REVIEW = [
+    "proves Chronos-RR",
+    "proves H4.1/FGL",
+    "proves P vs NP",
+    "solves any Clay problem",
+    "empirical validation achieved",
+    "theorem closure achieved",
+]
+
+
+def test_page_14_extract_exists():
+    assert PAGE.exists()
+    assert PAGE.read_text().strip()
+
+
+def test_page_14_review_tokens():
+    text = REVIEW.read_text()
+    for token in REQUIRED_REVIEW:
+        assert token in text, token
+
+
+def test_page_14_review_no_forbidden_promotions():
+    text = REVIEW.read_text()
+    for token in FORBIDDEN_REVIEW:
+        assert token not in text, token
+
+
+def test_page_14_plan_updated():
+    text = PLAN.read_text()
+    assert "| 14 | `docs/page_audits/v0.1.2/page_14.txt` | NO_CHANGE |" in text
+    assert "docs/page_audits/v0.1.2/reviews/page_14_review.md" in text


### PR DESCRIPTION
Adds the v0.1.2 page 14 audit review and updates the page-by-page plan from OPEN to NO_CHANGE. Boundary: review/status update only; no theorem closure, no unrestricted Chronos-RR, no H4.1/FGL, no P vs NP, no Clay problem, and no empirical-validation claim.