### PR TITLE
docs: add v0.1.2 page 17 boundary review

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -36,7 +36,7 @@ Does not prove:
 | 14 | `docs/page_audits/v0.1.2/page_14.txt` | NO_CHANGE | Continuing v0.1.2 audit page reviewed; see `docs/page_audits/v0.1.2/reviews/page_14_review.md`. |
 | 15 | `docs/page_audits/v0.1.2/page_15.txt` | NO_CHANGE | Continuing v0.1.2 audit page reviewed; see `docs/page_audits/v0.1.2/reviews/page_15_review.md`. |
 | 16 | `docs/page_audits/v0.1.2/page_16.txt` | NO_CHANGE | Continuing v0.1.2 audit page reviewed; see `docs/page_audits/v0.1.2/reviews/page_16_review.md`. |
-| 17 | `docs/page_audits/v0.1.2/page_17.txt` | OPEN | Pending page review. |
+| 17 | `docs/page_audits/v0.1.2/page_17.txt` | BOUNDARY_CLARIFICATION | Yang-Mills capacity-barrier example reviewed as interpretive framework language only; see `docs/page_audits/v0.1.2/reviews/page_17_review.md`. |
 | 18 | `docs/page_audits/v0.1.2/page_18.txt` | OPEN | Pending page review. |
 | 19 | `docs/page_audits/v0.1.2/page_19.txt` | OPEN | Pending page review. |
 | 20 | `docs/page_audits/v0.1.2/page_20.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_17_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_17_review.md
@@ -1,0 +1,31 @@
+# v0.1.2 Page 17 Review
+
+Status: `BOUNDARY_CLARIFICATION`
+
+Extract: `docs/page_audits/v0.1.2/page_17.txt`
+
+Review:
+
+Page 17 contains the Yang-Mills example sentence:
+
+`The coercive spectral floor acts as a capacity barrier. Violations correspond to forbidden persistent modes.`
+
+This sentence is interpretive framework language only. It must be read as a textbook-level analogy between spectral-gap/mass-gap questions and transcript-capacity rigidity.
+
+Boundary:
+
+This page does not prove:
+
+- Yang-Mills existence;
+- Yang-Mills mass gap;
+- any Clay problem;
+- unrestricted Chronos-RR;
+- H4.1/FGL;
+- P vs NP;
+- theorem-level closure of the capacity-barrier principle.
+
+No source rewrite is required at this step because the page is recorded as requiring boundary-aware interpretation rather than theorem promotion.
+
+Classification:
+
+`BOUNDARY_CLARIFICATION`

--- a/tests/test_v012_page_17_capacity_barrier_review.py
+++ b/tests/test_v012_page_17_capacity_barrier_review.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = ROOT / "docs/page_audits/v0.1.2/page_17.txt"
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_17_review.md"
+
+REQUIRED_PAGE = [
+    "Example: Yang–Mills",
+    "spectral gap and mass-gap questions",
+    "capacity barrier",
+    "persistent modes",
+]
+
+REQUIRED_REVIEW = [
+    "v0.1.2 Page 17 Review",
+    "Status: `BOUNDARY_CLARIFICATION`",
+    "Extract: `docs/page_audits/v0.1.2/page_17.txt`",
+    "Yang-Mills example sentence",
+    "interpretive framework language only",
+    "textbook-level analogy",
+    "spectral-gap/mass-gap questions",
+    "transcript-capacity rigidity",
+    "does not prove",
+    "Yang-Mills existence",
+    "Yang-Mills mass gap",
+    "any Clay problem",
+    "unrestricted Chronos-RR",
+    "H4.1/FGL",
+    "P vs NP",
+    "theorem-level closure of the capacity-barrier principle",
+    "No source rewrite is required",
+    "`BOUNDARY_CLARIFICATION`",
+]
+
+FORBIDDEN_REVIEW = [
+    "proves Yang-Mills",
+    "proves the Yang-Mills mass gap",
+    "solves Yang-Mills",
+    "solves any Clay problem",
+    "proves Chronos-RR",
+    "proves H4.1/FGL",
+    "proves P vs NP",
+    "theorem closure achieved",
+]
+
+
+def test_page_17_extract_tokens():
+    text = PAGE.read_text().replace("per-\nsistent", "persistent")
+    for token in REQUIRED_PAGE:
+        assert token in text, token
+
+
+def test_page_17_review_tokens():
+    text = REVIEW.read_text()
+    for token in REQUIRED_REVIEW:
+        assert token in text, token
+
+
+def test_page_17_review_no_forbidden_promotions():
+    text = REVIEW.read_text()
+    for token in FORBIDDEN_REVIEW:
+        assert token not in text, token
+
+
+def test_page_17_plan_updated():
+    text = PLAN.read_text()
+    assert "| 17 | `docs/page_audits/v0.1.2/page_17.txt` | BOUNDARY_CLARIFICATION |" in text
+    assert "docs/page_audits/v0.1.2/reviews/page_17_review.md" in text


### PR DESCRIPTION
Adds the v0.1.2 page 17 audit review and updates the page-by-page plan from OPEN to BOUNDARY_CLARIFICATION. Boundary: Yang-Mills capacity-barrier example is interpretive framework language only; no Yang-Mills existence proof, no Yang-Mills mass gap proof, no theorem closure, no unrestricted Chronos-RR, no H4.1/FGL, no P vs NP, and no Clay problem.