### PR TITLE
docs: add v0.1.2 page 18 review

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -37,7 +37,7 @@ Does not prove:
 | 15 | `docs/page_audits/v0.1.2/page_15.txt` | NO_CHANGE | Continuing v0.1.2 audit page reviewed; see `docs/page_audits/v0.1.2/reviews/page_15_review.md`. |
 | 16 | `docs/page_audits/v0.1.2/page_16.txt` | NO_CHANGE | Continuing v0.1.2 audit page reviewed; see `docs/page_audits/v0.1.2/reviews/page_16_review.md`. |
 | 17 | `docs/page_audits/v0.1.2/page_17.txt` | BOUNDARY_CLARIFICATION | Yang-Mills capacity-barrier example reviewed as interpretive framework language only; see `docs/page_audits/v0.1.2/reviews/page_17_review.md`. |
-| 18 | `docs/page_audits/v0.1.2/page_18.txt` | OPEN | Pending page review. |
+| 18 | `docs/page_audits/v0.1.2/page_18.txt` | NO_CHANGE | Continuing v0.1.2 audit page reviewed; see `docs/page_audits/v0.1.2/reviews/page_18_review.md`. |
 | 19 | `docs/page_audits/v0.1.2/page_19.txt` | OPEN | Pending page review. |
 | 20 | `docs/page_audits/v0.1.2/page_20.txt` | OPEN | Pending page review. |
 | 21 | `docs/page_audits/v0.1.2/page_21.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_18_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_18_review.md
@@ -1,0 +1,19 @@
+# v0.1.2 Page 18 Review
+
+Status: `NO_CHANGE`
+
+Extract: `docs/page_audits/v0.1.2/page_18.txt`
+
+Review:
+
+Page 18 is a continuation page in the v0.1.2 textbook audit sequence.
+
+The page does not introduce a new theorem-closure claim, unrestricted Chronos-RR claim, H4.1/FGL claim, P vs NP claim, Clay-problem claim, Yang-Mills mass-gap claim, or empirical-validation claim requiring page-local correction.
+
+Boundary:
+
+No source rewrite is required for this page.
+
+Classification:
+
+`NO_CHANGE`

--- a/tests/test_v012_page_18_continuation_review.py
+++ b/tests/test_v012_page_18_continuation_review.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = ROOT / "docs/page_audits/v0.1.2/page_18.txt"
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_18_review.md"
+
+REQUIRED_REVIEW = [
+    "v0.1.2 Page 18 Review",
+    "Status: `NO_CHANGE`",
+    "Extract: `docs/page_audits/v0.1.2/page_18.txt`",
+    "continuation page",
+    "v0.1.2 textbook audit sequence",
+    "does not introduce a new theorem-closure claim",
+    "unrestricted Chronos-RR claim",
+    "H4.1/FGL claim",
+    "P vs NP claim",
+    "Clay-problem claim",
+    "Yang-Mills mass-gap claim",
+    "empirical-validation claim",
+    "No source rewrite is required",
+    "`NO_CHANGE`",
+]
+
+FORBIDDEN_REVIEW = [
+    "proves Chronos-RR",
+    "proves H4.1/FGL",
+    "proves P vs NP",
+    "solves any Clay problem",
+    "proves Yang-Mills",
+    "proves the Yang-Mills mass gap",
+    "empirical validation achieved",
+    "theorem closure achieved",
+]
+
+
+def test_page_18_extract_exists():
+    assert PAGE.exists()
+    assert PAGE.read_text().strip()
+
+
+def test_page_18_review_tokens():
+    text = REVIEW.read_text()
+    for token in REQUIRED_REVIEW:
+        assert token in text, token
+
+
+def test_page_18_review_no_forbidden_promotions():
+    text = REVIEW.read_text()
+    for token in FORBIDDEN_REVIEW:
+        assert token not in text, token
+
+
+def test_page_18_plan_updated():
+    text = PLAN.read_text()
+    assert "| 18 | `docs/page_audits/v0.1.2/page_18.txt` | NO_CHANGE |" in text
+    assert "docs/page_audits/v0.1.2/reviews/page_18_review.md" in text


### PR DESCRIPTION
Adds the v0.1.2 page 18 audit review and updates the page-by-page plan from OPEN to NO_CHANGE. Boundary: review/status update only; no theorem closure, no unrestricted Chronos-RR, no H4.1/FGL, no P vs NP, no Clay problem, no Yang-Mills mass-gap claim, and no empirical-validation claim.