### PR TITLE
docs: add v0.1.2 page 19 boundary review

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -38,7 +38,7 @@ Does not prove:
 | 16 | `docs/page_audits/v0.1.2/page_16.txt` | NO_CHANGE | Continuing v0.1.2 audit page reviewed; see `docs/page_audits/v0.1.2/reviews/page_16_review.md`. |
 | 17 | `docs/page_audits/v0.1.2/page_17.txt` | BOUNDARY_CLARIFICATION | Yang-Mills capacity-barrier example reviewed as interpretive framework language only; see `docs/page_audits/v0.1.2/reviews/page_17_review.md`. |
 | 18 | `docs/page_audits/v0.1.2/page_18.txt` | NO_CHANGE | Continuing v0.1.2 audit page reviewed; see `docs/page_audits/v0.1.2/reviews/page_18_review.md`. |
-| 19 | `docs/page_audits/v0.1.2/page_19.txt` | OPEN | Pending page review. |
+| 19 | `docs/page_audits/v0.1.2/page_19.txt` | BOUNDARY_CLARIFICATION | Riemann Hypothesis capacity-escape example reviewed as interpretive framework language only; see `docs/page_audits/v0.1.2/reviews/page_19_review.md`. |
 | 20 | `docs/page_audits/v0.1.2/page_20.txt` | OPEN | Pending page review. |
 | 21 | `docs/page_audits/v0.1.2/page_21.txt` | OPEN | Pending page review. |
 | 22 | `docs/page_audits/v0.1.2/page_22.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_19_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_19_review.md
@@ -1,0 +1,32 @@
+# v0.1.2 Page 19 Review
+
+Status: `BOUNDARY_CLARIFICATION`
+
+Extract: `docs/page_audits/v0.1.2/page_19.txt`
+
+Review:
+
+Page 19 contains the Riemann Hypothesis example sentence:
+
+`Spectral coercivity prevents drift. Failure would imply a capacity-escaping mode.`
+
+This sentence is interpretive framework language only. It must be read as a textbook-level analogy between Euler-Gram spectral coercivity, rigidity principles, and capacity-escape obstruction language.
+
+Boundary:
+
+This page does not prove:
+
+- the Riemann Hypothesis;
+- Euler-Gram coercivity;
+- positivity of the Euler-Gram operator;
+- any Clay problem;
+- unrestricted Chronos-RR;
+- H4.1/FGL;
+- P vs NP;
+- theorem-level closure of the capacity-escape principle.
+
+No source rewrite is required at this step because the page is recorded as requiring boundary-aware interpretation rather than theorem promotion.
+
+Classification:
+
+`BOUNDARY_CLARIFICATION`

--- a/tests/test_v012_page_19_riemann_boundary_review.py
+++ b/tests/test_v012_page_19_riemann_boundary_review.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = ROOT / "docs/page_audits/v0.1.2/page_19.txt"
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_19_review.md"
+
+REQUIRED_PAGE = [
+    "Example: Riemann Hypothesis",
+    "Euler–Gram operator",
+    "rigidity principles",
+    "Spectral coercivity prevents drift",
+    "capacity-escaping mode",
+]
+
+REQUIRED_REVIEW = [
+    "v0.1.2 Page 19 Review",
+    "Status: `BOUNDARY_CLARIFICATION`",
+    "Extract: `docs/page_audits/v0.1.2/page_19.txt`",
+    "Riemann Hypothesis example sentence",
+    "interpretive framework language only",
+    "textbook-level analogy",
+    "Euler-Gram spectral coercivity",
+    "capacity-escape obstruction language",
+    "does not prove",
+    "the Riemann Hypothesis",
+    "Euler-Gram coercivity",
+    "positivity of the Euler-Gram operator",
+    "any Clay problem",
+    "unrestricted Chronos-RR",
+    "H4.1/FGL",
+    "P vs NP",
+    "theorem-level closure of the capacity-escape principle",
+    "No source rewrite is required",
+    "`BOUNDARY_CLARIFICATION`",
+]
+
+FORBIDDEN_REVIEW = [
+    "proves the Riemann Hypothesis",
+    "solves the Riemann Hypothesis",
+    "proves Euler-Gram coercivity",
+    "proves positivity of the Euler-Gram operator",
+    "solves any Clay problem",
+    "proves Chronos-RR",
+    "proves H4.1/FGL",
+    "proves P vs NP",
+    "theorem closure achieved",
+]
+
+
+def test_page_19_extract_tokens():
+    text = PAGE.read_text()
+    for token in REQUIRED_PAGE:
+        assert token in text, token
+
+
+def test_page_19_review_tokens():
+    text = REVIEW.read_text()
+    for token in REQUIRED_REVIEW:
+        assert token in text, token
+
+
+def test_page_19_review_no_forbidden_promotions():
+    text = REVIEW.read_text()
+    for token in FORBIDDEN_REVIEW:
+        assert token not in text, token
+
+
+def test_page_19_plan_updated():
+    text = PLAN.read_text()
+    assert "| 19 | `docs/page_audits/v0.1.2/page_19.txt` | BOUNDARY_CLARIFICATION |" in text
+    assert "docs/page_audits/v0.1.2/reviews/page_19_review.md" in text


### PR DESCRIPTION
Adds the v0.1.2 page 19 audit review and updates the page-by-page plan from OPEN to BOUNDARY_CLARIFICATION. Boundary: Riemann Hypothesis capacity-escape example is interpretive framework language only; no Riemann Hypothesis proof, no Euler-Gram coercivity proof, no theorem closure, no unrestricted Chronos-RR, no H4.1/FGL, no P vs NP, and no Clay problem.