### PR TITLE
docs: add v0.1.2 page 20 review

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -39,7 +39,7 @@ Does not prove:
 | 17 | `docs/page_audits/v0.1.2/page_17.txt` | BOUNDARY_CLARIFICATION | Yang-Mills capacity-barrier example reviewed as interpretive framework language only; see `docs/page_audits/v0.1.2/reviews/page_17_review.md`. |
 | 18 | `docs/page_audits/v0.1.2/page_18.txt` | NO_CHANGE | Continuing v0.1.2 audit page reviewed; see `docs/page_audits/v0.1.2/reviews/page_18_review.md`. |
 | 19 | `docs/page_audits/v0.1.2/page_19.txt` | BOUNDARY_CLARIFICATION | Riemann Hypothesis capacity-escape example reviewed as interpretive framework language only; see `docs/page_audits/v0.1.2/reviews/page_19_review.md`. |
-| 20 | `docs/page_audits/v0.1.2/page_20.txt` | OPEN | Pending page review. |
+| 20 | `docs/page_audits/v0.1.2/page_20.txt` | NO_CHANGE | Riemann Hypothesis chapter-header continuation page reviewed; see `docs/page_audits/v0.1.2/reviews/page_20_review.md`. |
 | 21 | `docs/page_audits/v0.1.2/page_21.txt` | OPEN | Pending page review. |
 | 22 | `docs/page_audits/v0.1.2/page_22.txt` | OPEN | Pending page review. |
 | 23 | `docs/page_audits/v0.1.2/page_23.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_20_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_20_review.md
@@ -1,0 +1,19 @@
+# v0.1.2 Page 20 Review
+
+Status: `NO_CHANGE`
+
+Extract: `docs/page_audits/v0.1.2/page_20.txt`
+
+Review:
+
+Page 20 is a chapter-header continuation page for Chapter 7, Example: Riemann Hypothesis.
+
+The page does not introduce a new theorem-closure claim, Riemann Hypothesis proof claim, Euler-Gram coercivity claim, unrestricted Chronos-RR claim, H4.1/FGL claim, P vs NP claim, Clay-problem claim, or empirical-validation claim requiring page-local correction.
+
+Boundary:
+
+No source rewrite is required for this page.
+
+Classification:
+
+`NO_CHANGE`

--- a/tests/test_v012_page_20_riemann_chapter_header_review.py
+++ b/tests/test_v012_page_20_riemann_chapter_header_review.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = ROOT / "docs/page_audits/v0.1.2/page_20.txt"
+PLAN = ROOT / "docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md"
+REVIEW = ROOT / "docs/page_audits/v0.1.2/reviews/page_20_review.md"
+
+REQUIRED_PAGE = [
+    "CHAPTER 7",
+    "RIEMANN HYPOTHESIS",
+]
+
+REQUIRED_REVIEW = [
+    "v0.1.2 Page 20 Review",
+    "Status: `NO_CHANGE`",
+    "Extract: `docs/page_audits/v0.1.2/page_20.txt`",
+    "chapter-header continuation page",
+    "Riemann Hypothesis",
+    "does not introduce a new theorem-closure claim",
+    "Riemann Hypothesis proof claim",
+    "Euler-Gram coercivity claim",
+    "unrestricted Chronos-RR claim",
+    "H4.1/FGL claim",
+    "P vs NP claim",
+    "Clay-problem claim",
+    "empirical-validation claim",
+    "No source rewrite is required",
+    "`NO_CHANGE`",
+]
+
+FORBIDDEN_REVIEW = [
+    "proves the Riemann Hypothesis",
+    "solves the Riemann Hypothesis",
+    "proves Euler-Gram coercivity",
+    "solves any Clay problem",
+    "proves Chronos-RR",
+    "proves H4.1/FGL",
+    "proves P vs NP",
+    "theorem closure achieved",
+]
+
+
+def test_page_20_extract_tokens():
+    text = PAGE.read_text()
+    for token in REQUIRED_PAGE:
+        assert token in text, token
+
+
+def test_page_20_review_tokens():
+    text = REVIEW.read_text()
+    for token in REQUIRED_REVIEW:
+        assert token in text, token
+
+
+def test_page_20_review_no_forbidden_promotions():
+    text = REVIEW.read_text()
+    for token in FORBIDDEN_REVIEW:
+        assert token not in text, token
+
+
+def test_page_20_plan_updated():
+    text = PLAN.read_text()
+    assert "| 20 | `docs/page_audits/v0.1.2/page_20.txt` | NO_CHANGE |" in text
+    assert "docs/page_audits/v0.1.2/reviews/page_20_review.md" in text


### PR DESCRIPTION
Adds the v0.1.2 page 20 audit review and updates the page-by-page plan from OPEN to NO_CHANGE. Boundary: chapter-header review only; no Riemann Hypothesis proof, no Euler-Gram coercivity proof, no theorem closure, no unrestricted Chronos-RR, no H4.1/FGL, no P vs NP, no Clay problem, and no empirical-validation claim.