### PR TITLE
docs: add v0.1.2 page 25 review

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -44,7 +44,7 @@ Does not prove:
 | 22 | `docs/page_audits/v0.1.2/page_22.txt` | NO_CHANGE | Reviewed in `docs/page_audits/v0.1.2/reviews/page_22_review.md`. |
 | 23 | `docs/page_audits/v0.1.2/page_23.txt` | NO_CHANGE | Reviewed in `docs/page_audits/v0.1.2/reviews/page_23_review.md`. |
 | 24 | `docs/page_audits/v0.1.2/page_24.txt` | NO_CHANGE | Reviewed in `docs/page_audits/v0.1.2/reviews/page_24_review.md`. |
-| 25 | `docs/page_audits/v0.1.2/page_25.txt` | OPEN | Pending page review. |
+| 25 | `docs/page_audits/v0.1.2/page_25.txt` | NO_CHANGE | Reviewed in `docs/page_audits/v0.1.2/reviews/page_25_review.md`. |
 | 26 | `docs/page_audits/v0.1.2/page_26.txt` | OPEN | Pending page review. |
 | 27 | `docs/page_audits/v0.1.2/page_27.txt` | OPEN | Pending page review. |
 | 28 | `docs/page_audits/v0.1.2/page_28.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_25_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_25_review.md
@@ -12,14 +12,14 @@ NO_CHANGE
 
 Page 25 was checked as part of the v0.1.2 page-by-page audit.
 
-The page remains within the v0.1.2 textbook chapter audit boundary. It is treated as exposition or framework-level language only unless the page text explicitly supplies a separately verified theorem, proof, or closure certificate.
+The page remains within the Appendix / Lean correspondence audit boundary. It is treated as exposition or framework-level language only unless the page text explicitly supplies a separately verified theorem, proof, or closure certificate.
 
 ## Boundary
 
 This review does not prove:
 
-- v0.1.2 textbook
-- chapter theorem boundary
+- Appendix / Lean correspondence
+- Lean module correspondence
 - theorem closure
 - unrestricted Chronos-RR
 - H4.1/FGL

--- a/docs/page_audits/v0.1.2/reviews/page_25_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_25_review.md
@@ -1,0 +1,32 @@
+# v0.1.2 Page 25 Review
+
+## Status
+
+NO_CHANGE
+
+## Source
+
+`docs/page_audits/v0.1.2/page_25.txt`
+
+## Review
+
+Page 25 was checked as part of the v0.1.2 page-by-page audit.
+
+The page remains within the v0.1.2 textbook chapter audit boundary. It is treated as exposition or framework-level language only unless the page text explicitly supplies a separately verified theorem, proof, or closure certificate.
+
+## Boundary
+
+This review does not prove:
+
+- v0.1.2 textbook
+- chapter theorem boundary
+- theorem closure
+- unrestricted Chronos-RR
+- H4.1/FGL
+- P vs NP
+- any Clay problem
+- empirical-validation claim
+
+## Audit decision
+
+`NO_CHANGE`

--- a/tests/test_v012_page_25_audit_review.py
+++ b/tests/test_v012_page_25_audit_review.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+PLAN = Path("docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md")
+REVIEW = Path("docs/page_audits/v0.1.2/reviews/page_25_review.md")
+
+REQUIRED_REVIEW = [
+    "v0.1.2 Page 25 Review",
+    "docs/page_audits/v0.1.2/page_25.txt",
+    "v0.1.2 textbook",
+    "chapter theorem boundary",
+    "theorem closure",
+    "unrestricted Chronos-RR",
+    "H4.1/FGL",
+    "P vs NP",
+    "any Clay problem",
+    "empirical-validation claim",
+    "`NO_CHANGE`",
+]
+
+FORBIDDEN_REVIEW = [
+    "proves a theorem closure",
+    "theorem closure achieved",
+    "unrestricted Chronos-RR proved",
+    "H4.1/FGL proved",
+    "P vs NP proved",
+    "Clay problem solved",
+    "empirical validation achieved",
+]
+
+
+def test_page_25_review_exists():
+    assert REVIEW.exists()
+
+
+def test_page_25_review_tokens():
+    text = REVIEW.read_text()
+    for token in REQUIRED_REVIEW:
+        assert token in text, token
+
+
+def test_page_25_review_no_forbidden_promotions():
+    text = REVIEW.read_text()
+    for token in FORBIDDEN_REVIEW:
+        assert token not in text, token
+
+
+def test_page_25_plan_updated():
+    text = PLAN.read_text()
+    assert "| 25 | `docs/page_audits/v0.1.2/page_25.txt` | NO_CHANGE |" in text
+    assert "docs/page_audits/v0.1.2/reviews/page_25_review.md" in text

--- a/tests/test_v012_page_25_audit_review.py
+++ b/tests/test_v012_page_25_audit_review.py
@@ -6,8 +6,8 @@ REVIEW = Path("docs/page_audits/v0.1.2/reviews/page_25_review.md")
 REQUIRED_REVIEW = [
     "v0.1.2 Page 25 Review",
     "docs/page_audits/v0.1.2/page_25.txt",
-    "v0.1.2 textbook",
-    "chapter theorem boundary",
+    "Appendix / Lean correspondence",
+    "Lean module correspondence",
     "theorem closure",
     "unrestricted Chronos-RR",
     "H4.1/FGL",


### PR DESCRIPTION
Adds the v0.1.2 page 25 audit review and updates the page-by-page plan from OPEN to the computed audit status. Boundary: page-audit review only; no chapter theorem proof, no theorem closure, no unrestricted Chronos-RR, no H4.1/FGL, no P vs NP, no Clay problem, and no empirical-validation claim.