### PR TITLE
docs: add v0.1.2 page 26 review

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -45,7 +45,7 @@ Does not prove:
 | 23 | `docs/page_audits/v0.1.2/page_23.txt` | NO_CHANGE | Reviewed in `docs/page_audits/v0.1.2/reviews/page_23_review.md`. |
 | 24 | `docs/page_audits/v0.1.2/page_24.txt` | NO_CHANGE | Reviewed in `docs/page_audits/v0.1.2/reviews/page_24_review.md`. |
 | 25 | `docs/page_audits/v0.1.2/page_25.txt` | NO_CHANGE | Reviewed in `docs/page_audits/v0.1.2/reviews/page_25_review.md`. |
-| 26 | `docs/page_audits/v0.1.2/page_26.txt` | OPEN | Pending page review. |
+| 26 | `docs/page_audits/v0.1.2/page_26.txt` | NO_CHANGE | Reviewed in `docs/page_audits/v0.1.2/reviews/page_26_review.md`. |
 | 27 | `docs/page_audits/v0.1.2/page_27.txt` | OPEN | Pending page review. |
 | 28 | `docs/page_audits/v0.1.2/page_28.txt` | OPEN | Pending page review. |
 | 29 | `docs/page_audits/v0.1.2/page_29.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_26_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_26_review.md
@@ -1,0 +1,32 @@
+# v0.1.2 Page 26 Review
+
+## Status
+
+NO_CHANGE
+
+## Source
+
+`docs/page_audits/v0.1.2/page_26.txt`
+
+## Review
+
+Page 26 was checked as part of the v0.1.2 page-by-page audit.
+
+The page remains within the Appendix / Lean correspondence audit boundary. It is treated as exposition, correspondence, or framework-level language only unless the page text explicitly supplies a separately verified theorem, proof, or closure certificate.
+
+## Boundary
+
+This review does not prove:
+
+- Appendix / Lean correspondence
+- Lean module correspondence
+- theorem closure
+- unrestricted Chronos-RR
+- H4.1/FGL
+- P vs NP
+- any Clay problem
+- empirical-validation claim
+
+## Audit decision
+
+`NO_CHANGE`

--- a/tests/test_v012_page_26_audit_review.py
+++ b/tests/test_v012_page_26_audit_review.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+PLAN = Path("docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md")
+REVIEW = Path("docs/page_audits/v0.1.2/reviews/page_26_review.md")
+
+REQUIRED_REVIEW = [
+    "v0.1.2 Page 26 Review",
+    "docs/page_audits/v0.1.2/page_26.txt",
+    "Appendix / Lean correspondence",
+    "Lean module correspondence",
+    "theorem closure",
+    "unrestricted Chronos-RR",
+    "H4.1/FGL",
+    "P vs NP",
+    "any Clay problem",
+    "empirical-validation claim",
+    "`NO_CHANGE`",
+]
+
+FORBIDDEN_REVIEW = [
+    "proves Lean correspondence theorem closure",
+    "theorem closure achieved",
+    "unrestricted Chronos-RR proved",
+    "H4.1/FGL proved",
+    "P vs NP proved",
+    "Clay problem solved",
+    "empirical validation achieved",
+]
+
+
+def test_page_26_review_exists():
+    assert REVIEW.exists()
+
+
+def test_page_26_review_tokens():
+    text = REVIEW.read_text()
+    for token in REQUIRED_REVIEW:
+        assert token in text, token
+
+
+def test_page_26_review_no_forbidden_promotions():
+    text = REVIEW.read_text()
+    for token in FORBIDDEN_REVIEW:
+        assert token not in text, token
+
+
+def test_page_26_plan_updated():
+    text = PLAN.read_text()
+    assert "| 26 | `docs/page_audits/v0.1.2/page_26.txt` | NO_CHANGE |" in text
+    assert "docs/page_audits/v0.1.2/reviews/page_26_review.md" in text


### PR DESCRIPTION
Adds the v0.1.2 page 26 audit review and updates the page-by-page plan from OPEN to the computed audit status. Boundary: page-audit review only; no chapter theorem proof, no theorem closure, no unrestricted Chronos-RR, no H4.1/FGL, no P vs NP, no Clay problem, and no empirical-validation claim.