### PR TITLE
docs: add v0.1.2 page 28 review

### DIFF
--- a/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
+++ b/docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md
@@ -47,7 +47,7 @@ Does not prove:
 | 25 | `docs/page_audits/v0.1.2/page_25.txt` | NO_CHANGE | Reviewed in `docs/page_audits/v0.1.2/reviews/page_25_review.md`. |
 | 26 | `docs/page_audits/v0.1.2/page_26.txt` | NO_CHANGE | Reviewed in `docs/page_audits/v0.1.2/reviews/page_26_review.md`. |
 | 27 | `docs/page_audits/v0.1.2/page_27.txt` | NO_CHANGE | Reviewed in `docs/page_audits/v0.1.2/reviews/page_27_review.md`. |
-| 28 | `docs/page_audits/v0.1.2/page_28.txt` | OPEN | Pending page review. |
+| 28 | `docs/page_audits/v0.1.2/page_28.txt` | NO_CHANGE | Reviewed in `docs/page_audits/v0.1.2/reviews/page_28_review.md`. |
 | 29 | `docs/page_audits/v0.1.2/page_29.txt` | OPEN | Pending page review. |
 | 30 | `docs/page_audits/v0.1.2/page_30.txt` | OPEN | Pending page review. |
 | 31 | `docs/page_audits/v0.1.2/page_31.txt` | OPEN | Pending page review. |

--- a/docs/page_audits/v0.1.2/reviews/page_28_review.md
+++ b/docs/page_audits/v0.1.2/reviews/page_28_review.md
@@ -1,0 +1,32 @@
+# v0.1.2 Page 28 Review
+
+## Status
+
+NO_CHANGE
+
+## Source
+
+`docs/page_audits/v0.1.2/page_28.txt`
+
+## Review
+
+Page 28 was checked as part of the v0.1.2 page-by-page audit.
+
+The page remains within the Appendix A / certificate admissibility audit boundary. It is treated as exposition, correspondence, metadata, or framework-level language only unless the page text explicitly supplies a separately verified theorem, proof, or closure certificate.
+
+## Boundary
+
+This review does not prove:
+
+- Appendix A / certificate admissibility
+- structural admissibility certificates
+- theorem closure
+- unrestricted Chronos-RR
+- H4.1/FGL
+- P vs NP
+- any Clay problem
+- empirical-validation claim
+
+## Audit decision
+
+`NO_CHANGE`

--- a/tests/test_v012_page_28_audit_review.py
+++ b/tests/test_v012_page_28_audit_review.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+PLAN = Path("docs/page_audits/v0.1.2/PAGE_BY_PAGE_UPDATE_PLAN.md")
+REVIEW = Path("docs/page_audits/v0.1.2/reviews/page_28_review.md")
+
+REQUIRED_REVIEW = [
+    "v0.1.2 Page 28 Review",
+    "docs/page_audits/v0.1.2/page_28.txt",
+    "Appendix A / certificate admissibility",
+    "structural admissibility certificates",
+    "theorem closure",
+    "unrestricted Chronos-RR",
+    "H4.1/FGL",
+    "P vs NP",
+    "any Clay problem",
+    "empirical-validation claim",
+    "`NO_CHANGE`",
+]
+
+FORBIDDEN_REVIEW = [
+    "proves certificate admissibility theorem closure",
+    "theorem closure achieved",
+    "unrestricted Chronos-RR proved",
+    "H4.1/FGL proved",
+    "P vs NP proved",
+    "Clay problem solved",
+    "empirical validation achieved",
+]
+
+
+def test_page_28_review_exists():
+    assert REVIEW.exists()
+
+
+def test_page_28_review_tokens():
+    text = REVIEW.read_text()
+    for token in REQUIRED_REVIEW:
+        assert token in text, token
+
+
+def test_page_28_review_no_forbidden_promotions():
+    text = REVIEW.read_text()
+    for token in FORBIDDEN_REVIEW:
+        assert token not in text, token
+
+
+def test_page_28_plan_updated():
+    text = PLAN.read_text()
+    assert "| 28 | `docs/page_audits/v0.1.2/page_28.txt` | NO_CHANGE |" in text
+    assert "docs/page_audits/v0.1.2/reviews/page_28_review.md" in text


### PR DESCRIPTION
Adds the v0.1.2 page 28 audit review and updates the page-by-page plan from OPEN to the computed audit status. Boundary: page-audit review only; no chapter theorem proof, no theorem closure, no unrestricted Chronos-RR, no H4.1/FGL, no P vs NP, no Clay problem, and no empirical-validation claim.