### PR TITLE
fix release workflow Node 24 compatibility

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -10,6 +10,8 @@ permissions:
 
 jobs:
   release:
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Opts the release-on-tag workflow into Node.js 24 for JavaScript actions. Boundary: CI maintenance only; no textbook content change.