### PR TITLE
docs: add v0.6.1 content density expansion roadmap

### DIFF
--- a/docs/status/V061_CONTENT_DENSITY_EXPANSION_ROADMAP_2026_05_27.md
+++ b/docs/status/V061_CONTENT_DENSITY_EXPANSION_ROADMAP_2026_05_27.md
@@ -1,0 +1,34 @@
+# v0.6.1 Content Density Expansion Roadmap
+
+Status: STRUCTURAL_SCAFFOLD_RELEASED_CONTENT_EXPANSION_OPEN
+
+The v0.6.1 release is build-valid and release-valid, but it remains content-light.
+
+Required expansion unit for each major theorem chapter:
+
+1. Definitions
+2. Hypotheses
+3. Formal theorem statement
+4. Proof or proof sketch
+5. Worked example
+6. Boundary / non-claim note
+7. Repository verification reference where applicable
+
+Priority chapters:
+
+- Capacity-Entropy Constraint
+- Locality Refinement Bound
+- Spectral Coercivity
+- EntropyDepth Lower Bound
+- Cycle-Overlap Rigidity
+- Local-Global Rigidity Transfer
+- Normalization Principle
+- Information Capacity Limit
+
+Boundary:
+
+This roadmap does not claim theorem-level completion.
+It does not prove unrestricted Chronos-RR.
+It does not prove unrestricted H4.1/FGL.
+It does not prove P vs NP.
+It does not prove any Clay problem.


### PR DESCRIPTION
Records that v0.6.1 is release-valid but content-light, and defines the required expansion unit for theorem chapters. Boundary: roadmap only; no theorem-level completion claim.