### PR TITLE
docs: expand chapter 8 worked examples

### DIFF
--- a/tex/chapters/07_examples.tex
+++ b/tex/chapters/07_examples.tex
@@ -1,33 +1,261 @@
 \chapter{Worked Examples}
 
-\section{Cycle Graph Example}
+\section{Purpose of Worked Examples}
 
-Let \(C_n\) be the cycle graph on \(n\) vertices.
+This chapter gives explicit toy calculations for the invariants introduced in
+the previous chapters. Each example follows the same pattern:
 
+\begin{enumerate}
+\item identify the state space;
+\item identify the entropy or unresolved defect;
+\item identify the admissible refinement step;
+\item compute or bound the per-step capacity;
+\item derive the resulting depth or rigidity estimate;
+\item state the boundary of the example.
+\end{enumerate}
+
+The examples are deliberately elementary. Their purpose is to show how the
+URF bookkeeping works before applying it to more complicated domains.
+
+\section{Finite Search Space Example}
+
+Let \(\Omega_n\) be a finite search space with
 \[
-\lambda_k = 2 - 2\cos\left(\frac{2\pi k}{n}\right)
+|\Omega_n|=2^n.
+\]
+Using base-two entropy, the initial unresolved entropy is
+\[
+H_0=\log_2|\Omega_n|=n.
 \]
 
-The spectral gap is
-
+Suppose an admissible refinement step removes at most \(c>0\) bits of
+information. Then the EntropyDepth lower bound gives
 \[
-\lambda_1 = 2 - 2\cos\left(\frac{2\pi}{n}\right).
+\ED\ge \frac{H_0}{c}=\frac{n}{c}.
 \]
 
-\section{EntropyDepth Example}
+\begin{example}[One-bit refinement]
+If \(c=1\), then at least \(n\) admissible refinement steps are required to
+isolate one configuration from \(2^n\) possibilities.
+\end{example}
 
-For a refinement system with initial entropy \(H_0\) and per-step entropy reduction bounded by \(c\),
+\begin{remark}[Boundary]
+This is a lower bound for the declared refinement model only. It does not rule
+out a different algorithmic model with larger admissible information access.
+\end{remark}
 
+\section{Bounded Branching Partition Example}
+
+Let \(P_t\) be a partition of a finite configuration space \(\Omega\), and let
+\(B_t\in P_t\) be the block containing the true configuration. Define
 \[
-D \ge \frac{H_0}{c}.
+H(P_t)=\log |B_t|.
 \]
+
+Assume each refinement step splits \(B_t\) into at most \(b\) effectively
+distinguishable subblocks. Then the entropy decrease per step is at most
+\[
+\log b.
+\]
+If \(|B_0|=N\), then terminal isolation requires
+\[
+\ED(P_0)\ge \frac{\log N}{\log b}.
+\]
+
+\begin{example}[Binary splitting]
+If \(b=2\), each step performs at most one binary distinction. If
+\(|B_0|=2^n\), then the depth lower bound is \(n\).
+\end{example}
 
 \section{Capacity Constraint Example}
 
-For capacity \(C\) and configuration entropy \(H\),
+A capacity constraint should be read as a one-step bound, not as a universal
+realizability condition.
 
+Let \(H(x)\) be the unresolved entropy of a state \(x\), and let \(C\) be the
+maximum entropy removed by one admissible step. If
 \[
-H \le C
+H(x)>C,
+\]
+then \(x\) need not be impossible. Rather, \(x\) cannot be fully resolved in
+one admissible step.
+
+\begin{theorem}[One-Step Capacity Interpretation]
+If terminal resolution requires entropy zero and one step removes at most
+\(C\) entropy, then a state \(x\) with \(H(x)>C\) requires more than one
+admissible step to resolve.
+\end{theorem}
+
+\begin{proof}
+If \(x\) were resolved in one step, the entropy removed in that step would be
+\(H(x)\). This contradicts the assumption that one step removes at most
+\(C<H(x)\) entropy.
+\end{proof}
+
+\section{Cycle Graph Spectral Example}
+
+Let \(C_n\) be the cycle graph on \(n\) vertices. The graph Laplacian
+eigenvalues are
+\[
+\lambda_k=2-2\cos\left(\frac{2\pi k}{n}\right),
+\qquad
+k=0,\ldots,n-1.
+\]
+The first nonzero eigenvalue is
+\[
+\lambda_1=2-2\cos\left(\frac{2\pi}{n}\right).
 \]
 
-is required for realizability.
+For large \(n\), the approximation
+\[
+1-\cos x\sim \frac{x^2}{2}
+\]
+gives
+\[
+\lambda_1\sim \frac{4\pi^2}{n^2}.
+\]
+Thus the spectral gap of \(C_n\) tends to zero as \(n\to\infty\).
+
+\begin{remark}[Interpretation]
+Cycle graphs do not form a uniform spectral expander family. In URF language,
+the spectral coercivity available from the Laplacian degenerates with system
+size.
+\end{remark}
+
+\section{Expander Contrast Example}
+
+Let \(G_n\) be a \(d\)-regular graph family with graph Laplacians \(L_n\).
+Suppose there is a uniform constant \(\lambda>0\) such that
+\[
+\lambda_1(L_n)\ge \lambda
+\]
+for every \(n\). Then for every \(f\perp\ker L_n\),
+\[
+\langle f,{L_n}f\rangle\ge \lambda\|f\|^2.
+\]
+
+\begin{theorem}[Uniform Coercivity Example]
+Under the uniform spectral gap assumption,
+\[
+\|f\|^2\le \lambda^{-1}\langle f,{L_n}f\rangle
+\]
+for every \(f\perp\ker L_n\).
+\end{theorem}
+
+\begin{proof}
+Divide the inequality
+\[
+\langle f,{L_n}f\rangle\ge \lambda\|f\|^2
+\]
+by \(\lambda>0\).
+\end{proof}
+
+This example shows how a spectral gap becomes a coercive estimate. It does
+not, by itself, provide an entropy-depth lower bound. Entropy and capacity
+data must still be supplied.
+
+\section{Local Graph Refinement Example}
+
+Let \(G\) be a graph of maximum degree \(\Delta\), and fix a radius \(R\). The
+number of vertices in a radius-\(R\) ball is at most
+\[
+1+\Delta+\Delta^2+\cdots+\Delta^R.
+\]
+If vertex labels lie in an alphabet of size \(A\), then the number of possible
+labeled local views is bounded by
+\[
+A^{1+\Delta+\cdots+\Delta^R}
+\]
+up to the additional choice of local adjacency pattern.
+
+Thus, for fixed \(A\), \(\Delta\), and \(R\), the local view has bounded type
+complexity independent of the total graph size.
+
+\begin{example}[Bounded local information]
+If an admissible refinement rule only sees radius-\(R\) labeled neighborhoods
+in a bounded-degree graph, then one local update cannot directly encode an
+unbounded amount of global graph information.
+\end{example}
+
+\section{Parallel Update Example}
+
+Suppose a parallel round consists of at most \(m\) local updates, and each
+local update removes at most \(c_{\mathrm{loc}}\) entropy. Then one parallel
+round removes at most
+\[
+mc_{\mathrm{loc}}
+\]
+entropy.
+
+If \(m\) is fixed, this gives a uniform round capacity. If \(m\) grows with
+the system size, the round capacity also grows, and a constant-capacity lower
+bound no longer follows.
+
+\begin{remark}[Accounting convention]
+Parallel examples require an explicit accounting convention. One must state
+whether depth is counted per local update, per synchronized round, per
+processor, or per global refinement operation.
+\end{remark}
+
+\section{Finite Detector Example}
+
+Suppose a measurement device has \(B\) distinguishable outcomes. A single
+measurement carries at most
+\[
+\log B
+\]
+units of outcome information.
+
+If the unresolved operational entropy is \(H_0\), and terminal resolution
+requires eliminating that entropy, then the number of admissible measurements
+is bounded below by
+\[
+\frac{H_0}{\log B}.
+\]
+
+\begin{remark}[Physical boundary]
+This is an information-accounting example only. A physical theorem would also
+need dynamics, measurement coupling, noise assumptions, and an admissibility
+model.
+\end{remark}
+
+\section{Failed Example: Missing Soundness}
+
+Consider a proposed reduction from a source-domain problem to a refinement
+model. Suppose the refinement model has entropy \(H_0\) and capacity \(C\), so
+that the model has depth lower bound \(H_0/C\). This does not imply a
+source-domain lower bound unless every source-domain process being ruled out
+is represented by an admissible refinement trajectory.
+
+\begin{example}[Unsound transfer]
+If an algorithm solves the source problem by using a global certificate that
+is not represented in the refinement model, then the refinement-model lower
+bound does not apply to that algorithm.
+\end{example}
+
+This is why reduction soundness is a required field in the application
+checklist.
+
+\section{Example Audit Table}
+
+\begin{center}
+\begin{tabular}{lll}
+\toprule
+Example & Main invariant & Conclusion \\
+\midrule
+Finite search & entropy \(n\) & depth at least \(n/c\) \\
+Partition refinement & block entropy & depth at least \(\log N/\log b\) \\
+Cycle graph & spectral gap & gap tends to zero \\
+Expander family & spectral gap & uniform coercivity \\
+Local graph update & local type count & bounded local information \\
+Finite detector & outcome count & measurement lower bound \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\section{Boundary}
+
+This chapter provides worked examples of URF bookkeeping. It does not prove
+SAT lower bounds, graph-isomorphism lower bounds, physical impossibility
+theorems, unrestricted Chronos-RR, unrestricted H4.1/FGL, P vs NP, or any Clay
+problem.


### PR DESCRIPTION
Expands Chapter 8 from a light scaffold into a fuller worked-examples chapter covering finite search, partition refinement, capacity interpretation, cycle graphs, expanders, local graph refinement, parallel updates, detector examples, and soundness failure. Boundary: exposition expansion only; no unrestricted Chronos-RR, unrestricted H4.1/FGL, P vs NP, or Clay-problem claim.