### PR TITLE
docs: add bounded status sync note

### DIFF
--- a/artifacts/status/urf_textbook_bounded_status_sync_2026_06_09.json
+++ b/artifacts/status/urf_textbook_bounded_status_sync_2026_06_09.json
@@ -1,0 +1,32 @@
+{
+  "status": "BOUNDED_STATUS_SYNC_ONLY",
+  "date": "2026-06-09",
+  "repo": "urf-textbook",
+  "synchronized_objects": [
+    {
+      "source_repo": "urf-core",
+      "pr": 452,
+      "commit": "cf4ffe0",
+      "closed_object": "repository_native_bounded_status_certificate",
+      "boundary": "STATUS_CONJUNCTION_ONLY"
+    },
+    {
+      "source_repo": "chronos-urf-rr",
+      "pr": 648,
+      "commit": "284efa3c",
+      "closed_object": "concreteAnalyticPackageNextBuildStopLockCertificate",
+      "boundary": "STATUS_CERTIFICATE_ONLY"
+    }
+  ],
+  "claims_not_made": [
+    "unrestricted_graph_theorem",
+    "unrestricted_SLVed_closure",
+    "analytic_Einstein_matter_estimate_package_proof",
+    "gravity_closure",
+    "Chronos_RR",
+    "H4_FGL",
+    "P_vs_NP",
+    "Clay_problem_closure"
+  ],
+  "next_admissible_object": "Stop"
+}

--- a/docs/status/URF_TEXTBOOK_BOUNDED_STATUS_SYNC_2026_06_09.md
+++ b/docs/status/URF_TEXTBOOK_BOUNDED_STATUS_SYNC_2026_06_09.md
@@ -1,0 +1,37 @@
+# URF Textbook Bounded Status Sync — 2026-06-09
+
+Status: `BOUNDED_STATUS_SYNC_ONLY`
+
+This note synchronizes the textbook explanation layer with two bounded repository closures recorded on 2026-06-09.
+
+## Synchronized bounded objects
+
+1. `urf-core`
+   - PR: `#452`
+   - Commit: `cf4ffe0`
+   - Closed object: `repository_native_bounded_status_certificate`
+   - Meaning: status conjunction of repository-native Path5 intended-configuration closure and bounded planar SLVed closure with rank bound.
+
+2. `chronos-urf-rr`
+   - PR: `#648`
+   - Commit: `284efa3c`
+   - Closed object: `concreteAnalyticPackageNextBuildStopLockCertificate`
+   - Meaning: status certificate recording build closeout surface only, with no analytic package proof claimed.
+
+## Boundary
+
+This textbook sync is explanatory only.
+
+It does not claim:
+- unrestricted graph theorem;
+- unrestricted SLVed closure;
+- analytic Einstein-matter estimate package proof;
+- gravity closure;
+- Chronos-RR;
+- H4/FGL;
+- P vs NP;
+- any Clay-problem closure.
+
+## Next admissible object
+
+`Stop`.

--- a/tests/test_urf_textbook_bounded_status_sync.py
+++ b/tests/test_urf_textbook_bounded_status_sync.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import json
+
+ROOT = Path(__file__).resolve().parents[1]
+
+DOC = ROOT / "docs/status/URF_TEXTBOOK_BOUNDED_STATUS_SYNC_2026_06_09.md"
+ART = ROOT / "artifacts/status/urf_textbook_bounded_status_sync_2026_06_09.json"
+
+def test_bounded_status_sync_doc_boundary():
+    text = DOC.read_text()
+    assert "BOUNDED_STATUS_SYNC_ONLY" in text
+    assert "repository_native_bounded_status_certificate" in text
+    assert "concreteAnalyticPackageNextBuildStopLockCertificate" in text
+    assert "does not claim" in text
+    assert "P vs NP" in text
+    assert "Clay-problem closure" in text
+
+def test_bounded_status_sync_artifact_boundary():
+    data = json.loads(ART.read_text())
+    assert data["status"] == "BOUNDED_STATUS_SYNC_ONLY"
+    assert data["next_admissible_object"] == "Stop"
+    assert len(data["synchronized_objects"]) == 2
+    assert "P_vs_NP" in data["claims_not_made"]
+    assert "Clay_problem_closure" in data["claims_not_made"]


### PR DESCRIPTION
## Summary
- Adds bounded status sync note for 2026-06-09.
- Records URF-core PR #452 and chronos-urf-rr PR #648 as bounded/explanatory sync items.
- Adds JSON artifact and pytest guard.

## Boundary
EXPLANATORY_SYNC_ONLY.
NO_NEW_THEOREM.
NO_UNRESTRICTED_GRAPH_THEOREM.
NO_UNRESTRICTED_SLVED_CLOSURE.
NO_ANALYTIC_PACKAGE_PROOF.
NO_CHRONOS_RR.
NO_H4FGL.
NO_P_VS_NP.
NO_CLAY_CLAIM.

## Verification
- `python3 -m pytest -q tests/test_urf_textbook_bounded_status_sync.py`
- `git diff --check`